### PR TITLE
Improve error message when file path isnt a file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "508b352bb5c066aac251f6daf6b36eccd03e8a88e8081cd44959ea277a3af9a8"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1233,7 @@ dependencies = [
 name = "inlyne"
 version = "0.1.5"
 dependencies = [
+ "anyhow",
  "bytemuck",
  "clap 3.2.16",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ copypasta = "0.8.1"
 resvg = { version = "0.23.0", features = ["text", "system-fonts", "memmap-fonts"] }
 usvg = "0.23.0"
 tiny-skia = "0.6.0"
+anyhow = "1.0.61"
 
 [profile.release]
 debug = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use color::Theme;
 use renderer::{Renderer, Spacer};
 use utils::{Align, Rect};
 
+use anyhow::Context;
 use comrak::{markdown_to_html, ComrakOptions};
 use copypasta::{ClipboardContext, ClipboardProvider};
 use html5ever::local_name;
@@ -32,8 +33,6 @@ use winit::{
 use Token::{CharacterTokens, EOFToken};
 
 use std::collections::VecDeque;
-use std::fs::File;
-use std::io::Read;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -879,19 +878,16 @@ struct Args {
     scale: Option<f32>,
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let theme = match args.theme {
         ThemeOption::Dark => color::DARK_DEFAULT,
         ThemeOption::Light => color::LIGHT_DEFAULT,
     };
+    let md_string = std::fs::read_to_string(&args.file_path)
+        .with_context(|| format!("No file found at {:?}", args.file_path))?;
+
     let inlyne = pollster::block_on(Inlyne::new(theme, args.scale.clone()));
-
-    let mut md_file = File::open(args.file_path.as_path()).unwrap();
-    let md_file_size = std::fs::metadata(args.file_path.as_path()).unwrap().len();
-    let mut md_string = String::with_capacity(md_file_size as usize);
-    md_file.read_to_string(&mut md_string).unwrap();
-
     let theme = inlyne.renderer.theme.clone();
     let element_queue_clone = inlyne.element_queue.clone();
     let hidpi_scale = args.scale.unwrap_or(inlyne.window.scale_factor() as f32);
@@ -943,4 +939,6 @@ fn main() {
         tok.end();
     });
     inlyne.run();
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -891,7 +891,7 @@ fn main() -> anyhow::Result<()> {
         ThemeOption::Light => color::LIGHT_DEFAULT,
     };
     let md_string = std::fs::read_to_string(&args.file_path)
-        .with_context(|| format!("Error reading file at {:?}", args.file_path))?;
+        .with_context(|| format!("Could not read file at {:?}", args.file_path))?;
 
     let inlyne = pollster::block_on(Inlyne::new(theme, args.scale.clone()));
     let theme = inlyne.renderer.theme.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,13 @@ impl Inlyne {
         let event_loop = EventLoop::<InlyneEvent>::with_user_event();
         let window = Arc::new(Window::new(&event_loop).unwrap());
         window.set_title("Inlyne");
-        let renderer = Renderer::new(&window, event_loop.create_proxy(), theme, scale.unwrap_or(window.scale_factor() as f32)).await;
+        let renderer = Renderer::new(
+            &window,
+            event_loop.create_proxy(),
+            theme,
+            scale.unwrap_or(window.scale_factor() as f32),
+        )
+        .await;
         let clipboard = ClipboardContext::new().unwrap();
 
         Self {
@@ -885,7 +891,7 @@ fn main() -> anyhow::Result<()> {
         ThemeOption::Light => color::LIGHT_DEFAULT,
     };
     let md_string = std::fs::read_to_string(&args.file_path)
-        .with_context(|| format!("No file found at {:?}", args.file_path))?;
+        .with_context(|| format!("Error reading file at {:?}", args.file_path))?;
 
     let inlyne = pollster::block_on(Inlyne::new(theme, args.scale.clone()));
     let theme = inlyne.renderer.theme.clone();


### PR DESCRIPTION
This change just tries to provide a friendlier message when there is a failure reading from the provided file

_Before_

```console
$ inlyne missing_file.md
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/main.rs:890:60
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

_After_

```console
$ inlyne missing_file.md
Error: Error reading file at "missing_file.md"

Caused by:
    No such file or directory (os error 2)
```