### PR TITLE
Remove `debug = true` for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,6 @@ resvg = { version = "0.23.0", features = ["text", "system-fonts", "memmap-fonts"
 usvg = "0.23.0"
 tiny-skia = "0.6.0"
 
-[profile.release]
-debug = true
+# Uncomment for profiling
+# [profile.release]
+# debug = true


### PR DESCRIPTION
It looks like this was added when when doing some profiling. Not including debug info makes the binary size a lot smaller for Linux users