### PR TITLE
Initial codeblock syntax highlighting support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,15 +60,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,21 +249,6 @@ checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
@@ -283,9 +259,9 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -373,7 +349,6 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf1e432b302dc6236dd0db580d182ce520bb24af82d6462e2d7a5e0a31c50d"
 dependencies = [
- "clap 2.34.0",
  "entities",
  "lazy_static",
  "memchr",
@@ -599,7 +574,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -1100,7 +1075,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "bytemuck",
- "clap 3.2.16",
+ "clap",
  "comrak",
  "copypasta",
  "html5ever",
@@ -2544,12 +2519,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -2639,15 +2608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2923,12 +2883,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ winit = "0.26.0"
 wgpu = "0.13.1"
 bytemuck = "1.11.0"
 lyon = "1.0.0"
-comrak = "0.14.0"
+comrak = { version = "0.14.0", default-features = false, features = ["syntect"] }
 open = "3.0.2"
 html5ever = "0.26.0"
 image = "0.24.3"

--- a/src/color.rs
+++ b/src/color.rs
@@ -18,6 +18,7 @@ pub struct Theme {
     pub code_block_color: [f32; 4],
     pub link_color: [f32; 4],
     pub select_color: [f32; 4],
+    pub code_highlighter: &'static str,
 }
 
 pub const DARK_DEFAULT: Theme = Theme {
@@ -28,17 +29,19 @@ pub const DARK_DEFAULT: Theme = Theme {
         b: 0.0086,
         a: 1.0,
     },
-    code_color: [1., 0.0578, 0.9331, 1.0],
+    code_color: [1. * 0.7, 0.0578 * 0.7, 0.9331 * 0.7, 1.0],
     code_block_color: [0.0080 * 1.5, 0.0110 * 1.5, 0.0156 * 1.5, 1.0],
     link_color: [0.0976, 0.3813, 1.0, 1.0],
     select_color: [0.17, 0.22, 0.3, 1.0],
+    code_highlighter: "base16-mocha.dark",
 };
 
 pub const LIGHT_DEFAULT: Theme = Theme {
     text_color: [0., 0., 0., 1.0],
     clear_color: wgpu::Color::WHITE,
     code_color: [1., 0.0578, 0.9331, 1.0],
-    code_block_color: [0.9, 0.9, 0.9, 1.0],
+    code_block_color: [0.92, 0.92, 0.92, 1.0],
     link_color: [0.0975, 0.1813, 1.0, 1.0],
     select_color: [0.67, 0.85, 0.9, 1.0],
+    code_highlighter: "InspiredGitHub",
 };

--- a/src/text.rs
+++ b/src/text.rs
@@ -18,6 +18,7 @@ pub struct TextBox {
     pub align: Align,
     pub hidpi_scale: f32,
     pub default_text_color: [f32; 4],
+    pub padding_height: f32,
 }
 
 impl TextBox {
@@ -29,6 +30,7 @@ impl TextBox {
             align: Align::Left,
             hidpi_scale,
             default_text_color: theme.text_color,
+            padding_height: 0.,
         }
     }
 
@@ -43,6 +45,11 @@ impl TextBox {
 
     pub fn with_indent(mut self, indent: f32) -> Self {
         self.indent = indent;
+        self
+    }
+
+    pub fn with_padding(mut self, padding_height: f32) -> Self {
+        self.padding_height = padding_height;
         self
     }
 
@@ -104,13 +111,14 @@ impl TextBox {
         bounds: (f32, f32),
     ) -> (f32, f32) {
         if self.texts.is_empty() {
-            return (0., 0.);
+            return (0., self.padding_height);
         }
+
         if let Some(bounds) = glyph_brush.glyph_bounds(&self.glyph_section(screen_position, bounds))
         {
-            (bounds.width(), bounds.height())
+            (bounds.width(), bounds.height() + self.padding_height)
         } else {
-            (0., 0.)
+            (0., self.padding_height)
         }
     }
 


### PR DESCRIPTION
Resolves #8

_The `comrak` feature tweaking is to get rid of the default `clap` feature which is only useful for the `comrak` binary_

This implements the initial support for syntax highlighting code blocks, but it seems there are some bugs in how some spans with just whitespace are handled (e.g. the lines starting with `async` and `return`) which I would appreciate some help troubleshooting since the `TokenPrinter` is a big ball of mutable state that is pretty hard to follow.

Here is some of the syntax highlighted code where the indentation is having some obvious issues. The indentation issues are reproducible when just having `comrak` include colored spans in codeblocks without any of the code for respecting the span's color

_Before_

![image](https://user-images.githubusercontent.com/30302768/184474597-8e3f0e9f-c49d-41f6-9471-f00a6788e2c3.png)

_After_

![image](https://user-images.githubusercontent.com/30302768/184474355-d4108899-ad50-496d-8a36-71bba713ef89.png)

---

Also worth noting that the HTML portion of the code snippet should also be indented, but isn't in either this PR or `main`

```js
// requires Bun v0.1.0 or later
// react-ssr.tsx
import { renderToReadableStream } from "react-dom/server";

const dt = new Intl.DateTimeFormat();

export default {
  port: 3000,
  async fetch(request: Request) {
    return new Response(
      await renderToReadableStream(
        <html>
          <head>
            <title>Hello World</title>
          </head>
          <body>
            <h1>Hello from React!</h1>
            <p>The date is {dt.format(new Date())}</p>
          </body>
        </html>
      )
    );
  },
};

// bun react-ssr.tsx
```
