### PR TITLE
Switch image min and mipmap filters to linear

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -371,6 +371,7 @@ impl ImageRenderer {
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
+            anisotropy_clamp: Some(std::num::NonZeroU8::new(4).expect("4 is not 0")),
             ..Default::default()
         });
         Self {

--- a/src/image.rs
+++ b/src/image.rs
@@ -369,9 +369,8 @@ impl ImageRenderer {
             address_mode_v: wgpu::AddressMode::ClampToEdge,
             address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Nearest,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            anisotropy_clamp: Some(std::num::NonZeroU8::new(4).expect("4 is not 0")),
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Linear,
             ..Default::default()
         });
         Self {


### PR DESCRIPTION
I know I said I was done with changes before the next release, but I was trying to figure out why some of the images had some obvious fuzziness. Setting an anisotropy clamp cleared it up, and from what I can tell this seems to have minimal impact on GPU usage (not surprising since this isn't an image heavy program)

All of these images are from using a window that is one quarter the size of my monitor with a scale of 1.5 since this exacerbates the issue. The second image is portion from the last image in bun's README

_Before_

![image](https://user-images.githubusercontent.com/30302768/184560526-6553db27-9706-415c-b879-19d2bd3433fc.png)

![image](https://user-images.githubusercontent.com/30302768/184560544-9f80f3b5-bab7-4c80-96e8-6e1c0a0647c8.png)

_After_

![image](https://user-images.githubusercontent.com/30302768/184560571-de0f8d7e-72f0-42d0-aa3e-456e970b8b1e.png)

![image](https://user-images.githubusercontent.com/30302768/184560606-ff513590-4229-4ac1-8aa1-90ffbaa89f5c.png)