### PR TITLE
Allow for specifying alignment in `<div>`s

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -292,7 +292,7 @@ impl TokenSink for HtmlInterpreter {
                             self.state.element_stack.push(match tag_name.as_str() {
                                 "div" => html::Element::Div(align),
                                 "p" => html::Element::Paragraph(align),
-                                _ => {},
+                                _ => unreachable!("Arm matches on div and p"),
                             });
                         }
                         "em" | "i" => self.state.text_options.italic += 1,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -444,7 +444,9 @@ impl TokenSink for HtmlInterpreter {
                         "code" => self.state.text_options.code -= 1,
                         "div" | "p" => {
                             self.push_current_textbox();
-                            self.push_spacer();
+                            if tag_name == "p" {
+                                self.push_spacer();
+                            }
                             self.state.element_stack.pop();
                         }
                         "em" | "i" => self.state.text_options.italic -= 1,

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -58,10 +58,6 @@ mod html {
         pub align: Option<Align>,
     }
 
-    pub struct Paragraph {
-        pub align: Option<Align>,
-    }
-
     #[derive(Debug)]
     pub enum ListType {
         Ordered(usize),
@@ -92,7 +88,8 @@ mod html {
         Table(Table),
         TableRow(Vec<TextBox>),
         Header(Header),
-        Paragraph(Paragraph),
+        Paragraph(Option<Align>),
+        Div(Option<Align>),
     }
 }
 
@@ -248,11 +245,11 @@ impl TokenSink for HtmlInterpreter {
                             }
                             if align.is_none() {
                                 for element in self.state.element_stack.iter().rev() {
-                                    if let html::Element::Paragraph(p) = element {
-                                        if let Some(ref p_align) = p.align {
-                                            align = Some(p_align.clone());
-                                            break;
-                                        }
+                                    if let html::Element::Div(Some(elem_align))
+                                    | html::Element::Paragraph(Some(elem_align)) = element
+                                    {
+                                        align = Some(*elem_align);
+                                        break;
                                     }
                                 }
                             }
@@ -275,7 +272,7 @@ impl TokenSink for HtmlInterpreter {
                                 }
                             }
                         }
-                        "p" => {
+                        "div" | "p" => {
                             let mut align = None;
                             for attr in tag.attrs {
                                 if attr.name.local == local_name!("align")
@@ -289,11 +286,14 @@ impl TokenSink for HtmlInterpreter {
                                     }
                                 }
                             }
-                            self.current_textbox
-                                .set_align(align.clone().unwrap_or(Align::Left));
-                            self.state
-                                .element_stack
-                                .push(html::Element::Paragraph(html::Paragraph { align }));
+                            if let Some(align) = align {
+                                self.current_textbox.set_align(align);
+                            }
+                            self.state.element_stack.push(match tag_name.as_str() {
+                                "div" => html::Element::Div(align),
+                                "p" => html::Element::Paragraph(align),
+                                _ => {},
+                            });
                         }
                         "em" | "i" => self.state.text_options.italic += 1,
                         "bold" | "strong" => self.state.text_options.bold += 1,
@@ -442,7 +442,7 @@ impl TokenSink for HtmlInterpreter {
                             self.state.text_options.link.pop();
                         }
                         "code" => self.state.text_options.code -= 1,
-                        "p" => {
+                        "div" | "p" => {
                             self.push_current_textbox();
                             self.push_spacer();
                             self.state.element_stack.pop();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,7 +33,7 @@ impl From<wgpu_glyph::ab_glyph::Rect> for Rect {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum Align {
     #[default]
     Left,


### PR DESCRIPTION
This PR was motivated by the decoration at the top of [`insta`'s README](https://github.com/mitsuhiko/insta/blob/master/README.md)

```html
<div align="center">
 <img src="https://github.com/mitsuhiko/insta/blob/master/assets/logo.png?raw=true" width="250" height="250">
 <p><strong>insta: a snapshot testing library for Rust</strong></p>
</div>
```

The two aspects of this PR are

1. Pushing div alignment onto the element stack
2. Only set `current_textbox` alignment when found

_Before_

![image](https://user-images.githubusercontent.com/30302768/184793455-83da7725-5a56-450d-a5bc-fef18bf56741.png)

_After_

![image](https://user-images.githubusercontent.com/30302768/184794061-0da973e2-0ae4-40b8-9c5c-8fcedc00a0e4.png)
