### PR TITLE
Tweak inline code colors

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -30,7 +30,7 @@ pub const DARK_DEFAULT: Theme = Theme {
         b: 0.0086,
         a: 1.0,
     },
-    code_color: [1. * 0.7, 0.0578 * 0.7, 0.9331 * 0.7, 1.0],
+    code_color: [0.2542, 0.4508, 0.4621, 1.0],
     code_block_color: [0.0080 * 1.5, 0.0110 * 1.5, 0.0156 * 1.5, 1.0],
     quote_block_color: [0.0080, 0.0110, 0.0156, 1.0],
     link_color: [0.0976, 0.3813, 1.0, 1.0],
@@ -41,7 +41,7 @@ pub const DARK_DEFAULT: Theme = Theme {
 pub const LIGHT_DEFAULT: Theme = Theme {
     text_color: [0., 0., 0., 1.0],
     clear_color: wgpu::Color::WHITE,
-    code_color: [1., 0.0578, 0.9331, 1.0],
+    code_color: [0.3864, 0.0123, 0.1095, 1.0],
     code_block_color: [0.92, 0.92, 0.92, 1.0],
     quote_block_color: [0.5841 * 1.5, 0.6376 * 1.5, 0.6939 * 1.5, 1.0],
     link_color: [0.0975, 0.1813, 1.0, 1.0],


### PR DESCRIPTION
The inline code color looks a bit out of place now that there code blocks have syntax highlighting

This PR changes the inline code colors based by picking an arbitrary color from the syntax highlighting. I just tried to pick a color that was both distinct from regular text color, link color, and something that would look like a clicked link color (I know the color doesn't change when they're clicked)

Feel free to bikeshed the colors!

_Before Light_

![image](https://user-images.githubusercontent.com/30302768/184799526-30695f6f-3828-4e2c-a89f-83fb288a0543.png)

_After Light_

![image](https://user-images.githubusercontent.com/30302768/184799900-d6f69835-087b-4fc0-b597-d9875abb441d.png)

_Before Dark_

![image](https://user-images.githubusercontent.com/30302768/184799735-a281f9ff-2e56-4170-9d53-226e2cdfce69.png)

_After Dark_

![image](https://user-images.githubusercontent.com/30302768/184800052-d8743419-b30b-4029-9e84-526f2dc136dd.png)