### PR TITLE
Fixup link clicking

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -243,8 +243,6 @@ impl Inlyne {
                             if !scrollbar_held {
                                 scrollbar_held = true;
                             }
-                        } else if self.renderer.selection.is_none() {
-                            self.renderer.selection = Some((loc, loc));
                         } else if let Some(selection) = &mut self.renderer.selection {
                             if mouse_down {
                                 selection.1 = loc;
@@ -258,6 +256,12 @@ impl Inlyne {
                         ..
                     } => match state {
                         ElementState::Pressed => {
+                            // Reset selection
+                            if self.renderer.selection.is_some() {
+                                self.renderer.selection = None;
+                                self.window.request_redraw();
+                            }
+
                             // Try to click a link
                             let screen_size = self.renderer.screen_size();
                             if let Some(hoverable) = Self::find_hoverable(
@@ -282,15 +286,15 @@ impl Inlyne {
                                             self.window.set_cursor_icon(CursorIcon::Default);
                                         }
                                     }
+                                } else if self.renderer.selection.is_none() {
+                                    // Only set selection when not over link
+                                    self.renderer.selection = Some((last_loc, last_loc));
                                 }
+                            } else if self.renderer.selection.is_none() {
+                                self.renderer.selection = Some((last_loc, last_loc));
                             }
 
-                            if self.renderer.selection.is_some() {
-                                self.renderer.selection = None;
-                                self.window.request_redraw();
-                            }
                             mouse_down = true;
-                            self.window.request_redraw();
                         }
                         ElementState::Released => {
                             scrollbar_held = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,7 @@ impl Inlyne {
         elements
             .iter()
             .find(|&e| e.contains(loc) && !matches!(e.deref(), Element::Spacer(_)))
-            .map(|element| match element.deref() {
+            .and_then(|element| match element.deref() {
                 Element::TextBox(text_box) => {
                     let bounds = element.bounds.as_ref().unwrap();
                     text_box
@@ -339,7 +339,7 @@ impl Inlyne {
                             screen_pos(screen_size, bounds.pos.0),
                             zoom,
                         )
-                        .map(|text| Hoverable::Text(text))
+                        .map(Hoverable::Text)
                 }
                 Element::Table(table) => {
                     let bounds = element.bounds.as_ref().unwrap();
@@ -351,12 +351,11 @@ impl Inlyne {
                             screen_pos(screen_size, bounds.pos.0),
                             zoom,
                         )
-                        .map(|text| Hoverable::Text(text))
+                        .map(Hoverable::Text)
                 }
                 Element::Image(image) => Some(Hoverable::Image(image)),
                 Element::Spacer(_) => unreachable!("Spacers are filtered"),
             })
-            .flatten()
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,11 +1,8 @@
-use std::collections::HashMap;
-
-use crate::utils::{Align, HoverInfo, Rect};
+use crate::utils::{Align, Rect};
 use wgpu_glyph::{
     ab_glyph::{Font, FontArc, PxScale},
     Extra, FontId, GlyphCruncher, HorizontalAlign, Layout, Section, SectionGlyph,
 };
-use winit::window::CursorIcon;
 
 #[derive(Clone, Debug, Default)]
 pub struct TextBox {
@@ -48,43 +45,23 @@ impl TextBox {
     pub fn set_align(&mut self, align: Align) {
         self.align = align;
     }
-    pub fn hovering_over<T: GlyphCruncher>(
-        &self,
-        anchors: &HashMap<String, f32>,
-        glyph_brush: &mut T,
+
+    pub fn find_hoverable<'a, T: GlyphCruncher>(
+        &'a self,
+        glyph_brush: &'a mut T,
         loc: (f32, f32),
         screen_position: (f32, f32),
         bounds: (f32, f32),
         zoom: f32,
-        click: bool,
-    ) -> HoverInfo {
+    ) -> Option<&'a Text> {
         let fonts: Vec<FontArc> = glyph_brush.fonts().to_vec();
-        if let Some(glyph) = glyph_brush
+        glyph_brush
             .glyphs(&self.glyph_section(screen_position, bounds, zoom))
             .find(|glyph| {
                 let bounds = Rect::from((fonts[glyph.font_id.0]).glyph_bounds(&glyph.glyph));
                 bounds.contains(loc)
             })
-        {
-            let text = &self.texts[glyph.section_index];
-            HoverInfo::from(if let Some(link) = &text.link {
-                if click && open::that(link).is_err() {
-                    if let Some(anchor_pos) = anchors.get(link) {
-                        return HoverInfo {
-                            jump: Some(*anchor_pos),
-                            ..Default::default()
-                        };
-                    } else {
-                        eprintln!("Error: Could not open link ({})", link);
-                    }
-                }
-                CursorIcon::Hand
-            } else {
-                CursorIcon::Text
-            })
-        } else {
-            HoverInfo::default()
-        }
+            .map(|glyph| &self.texts[glyph.section_index])
     }
 
     pub fn glyph_bounds<T: GlyphCruncher>(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -48,3 +48,12 @@ pub struct HoverInfo {
     pub cursor_icon: CursorIcon,
     pub jump: Option<f32>,
 }
+
+impl From<CursorIcon> for HoverInfo {
+    fn from(cursor_icon: CursorIcon) -> Self {
+        Self {
+            cursor_icon,
+            ..Default::default()
+        }
+    }
+}


### PR DESCRIPTION
The main motivation behind all of this is that clicking links without moving the mouse wouldn't actually open the link. This is because link clicking was implemented in a position change event, so pressing and releasing the LMB without moving the cursor wouldn't trigger it

This was fixed by moving the link clicking logic into the LMB press event. Most of the work here was refactoring to decouple the hover element checking from link clicking to avoid duplicating a bunch of logic

The scrollbar could use similar changes since it suffers from the same problem of clicks not registering unless the cursor is moved while clicking, but this is all I have time for tonight