### PR TITLE
Open markdown file links with inlyne

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,11 +91,11 @@ pub struct Inlyne {
     element_queue: Arc<Mutex<VecDeque<Element>>>,
     clipboard: ClipboardContext,
     elements: Vec<Positioned<Element>>,
-    args: crate::opts::Args,
+    args: Args,
 }
 
 impl Inlyne {
-    pub async fn new(opts: Opts, args: crate::opts::Args) -> anyhow::Result<Self> {
+    pub async fn new(opts: Opts, args: Args) -> anyhow::Result<Self> {
         let event_loop = EventLoop::<InlyneEvent>::with_user_event();
         let window = Arc::new(Window::new(&event_loop).unwrap());
         window.set_title("Inlyne");

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -32,7 +32,7 @@ impl ValueEnum for ThemeType {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Args {
     pub file_path: PathBuf,
     pub theme: Option<ThemeType>,
@@ -65,6 +65,20 @@ pub fn command(scale_help: &str, default_theme: ThemeType) -> Command {
 }
 
 impl Args {
+    pub fn args(&self) -> Vec<String> {
+        let mut args = Vec::new();
+        args.push(self.file_path.as_os_str().to_str().unwrap().to_string());
+        if let Some(theme) = self.theme {
+            args.push("--theme".to_owned());
+            args.push(theme.as_str().to_owned());
+        }
+        if let Some(scale) = self.scale {
+            args.push("--scale".to_owned());
+            args.push(scale.to_string());
+        }
+        args
+    }
+
     pub fn parse_from(args: Vec<OsString>, config: &Config) -> Self {
         let scale_help = format!(
             "Factor to scale rendered file by [default: {}]",

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -32,7 +32,7 @@ impl ValueEnum for ThemeType {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct Args {
     pub file_path: PathBuf,
     pub theme: Option<ThemeType>,

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -65,7 +65,12 @@ pub fn command(scale_help: &str, default_theme: ThemeType) -> Command {
 }
 
 impl Args {
-    pub fn args(&self) -> Vec<String> {
+    pub fn new(config: &Config) -> Self {
+        let program_args = std::env::args_os().collect();
+        Self::parse_from(program_args, config)
+    }
+
+    pub fn program_args(&self) -> Vec<String> {
         let mut args = Vec::new();
         args.push(self.file_path.as_os_str().to_str().unwrap().to_string());
         if let Some(theme) = self.theme {

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -3,13 +3,14 @@ mod config;
 #[cfg(test)]
 mod tests;
 
-use std::{env, ffi::OsString, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::color;
 
 use serde::Deserialize;
 
 pub use self::cli::Args;
+pub use self::config::Config;
 pub use self::config::FontOptions;
 
 #[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq)]
@@ -25,29 +26,10 @@ pub struct Opts {
     pub theme: color::Theme,
     pub scale: Option<f32>,
     pub font_opts: FontOptions,
-    pub args: Args,
 }
 
 impl Opts {
-    pub fn parse_and_load() -> Self {
-        let args = env::args_os().collect();
-        let config = match config::Config::load() {
-            Ok(config) => config,
-            Err(err) => {
-                // TODO: switch to logging
-                eprintln!(
-                    "WARN: Failed reading config file. Falling back to defaults. Error: {}",
-                    err
-                );
-                config::Config::default()
-            }
-        };
-
-        Self::parse_and_load_from(args, config)
-    }
-
-    fn parse_and_load_from(args: Vec<OsString>, config: config::Config) -> Self {
-        let args = cli::Args::parse_from(args, &config);
+    pub fn parse_and_load_from(args: &Args, config: config::Config) -> Self {
         let config::Config {
             theme: config_theme,
             scale: config_scale,
@@ -70,8 +52,7 @@ impl Opts {
         let font_opts = config_font_options.unwrap_or_default();
 
         Self {
-            args: args.clone(),
-            file_path: args.file_path,
+            file_path: args.file_path.clone(),
             theme,
             scale: args.scale.or(config_scale),
             font_opts,

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -9,6 +9,7 @@ use crate::color;
 
 use serde::Deserialize;
 
+pub use self::cli::Args;
 pub use self::config::FontOptions;
 
 #[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq)]
@@ -24,6 +25,7 @@ pub struct Opts {
     pub theme: color::Theme,
     pub scale: Option<f32>,
     pub font_opts: FontOptions,
+    pub args: Args,
 }
 
 impl Opts {
@@ -45,11 +47,7 @@ impl Opts {
     }
 
     fn parse_and_load_from(args: Vec<OsString>, config: config::Config) -> Self {
-        let cli::Args {
-            file_path,
-            theme: args_theme,
-            scale: args_scale,
-        } = cli::Args::parse_from(args, &config);
+        let args = cli::Args::parse_from(args, &config);
         let config::Config {
             theme: config_theme,
             scale: config_scale,
@@ -58,7 +56,7 @@ impl Opts {
             font_options: config_font_options,
         } = config;
 
-        let theme = match args_theme.unwrap_or(config_theme) {
+        let theme = match args.theme.unwrap_or(config_theme) {
             ThemeType::Dark => match config_dark_theme {
                 Some(config_dark_theme) => config_dark_theme.merge(color::DARK_DEFAULT),
                 None => color::DARK_DEFAULT,
@@ -72,9 +70,10 @@ impl Opts {
         let font_opts = config_font_options.unwrap_or_default();
 
         Self {
-            file_path,
+            args: args.clone(),
+            file_path: args.file_path,
             theme,
-            scale: args_scale.or(config_scale),
+            scale: args.scale.or(config_scale),
             font_opts,
         }
     }

--- a/src/opts/tests.rs
+++ b/src/opts/tests.rs
@@ -1,6 +1,7 @@
 use std::{ffi::OsString, path::PathBuf};
 
 use crate::opts::config::FontOptions;
+use crate::opts::Args;
 
 use super::{cli, config, Opts, ThemeType};
 
@@ -29,6 +30,7 @@ fn defaults() {
             theme: ThemeType::default().as_theme(),
             scale: None,
             font_opts: FontOptions::default(),
+            args: Args::default(),
         }
     );
 }
@@ -48,6 +50,7 @@ fn config_overrides_default() {
             theme: ThemeType::Dark.as_theme(),
             scale: None,
             font_opts: FontOptions::default(),
+            args: Args::default(),
         }
     );
     assert_eq!(
@@ -63,6 +66,7 @@ fn config_overrides_default() {
             theme: ThemeType::default().as_theme(),
             scale: Some(1.5),
             font_opts: FontOptions::default(),
+            args: Args::default(),
         }
     );
 }
@@ -79,6 +83,7 @@ fn from_cli() {
             theme: ThemeType::Dark.as_theme(),
             scale: None,
             font_opts: FontOptions::default(),
+            args: Args::default(),
         }
     );
 
@@ -97,6 +102,7 @@ fn from_cli() {
             theme: ThemeType::Dark.as_theme(),
             scale: Some(1.5),
             font_opts: FontOptions::default(),
+            args: Args::default(),
         }
     );
 }

--- a/src/opts/tests.rs
+++ b/src/opts/tests.rs
@@ -23,59 +23,63 @@ fn debug_assert() {
 
 #[test]
 fn defaults() {
+    let config = config::Config::default();
     assert_eq!(
-        Opts::parse_and_load_from(gen_args(vec!["file.md"]), config::Config::default()),
+        Opts::parse_and_load_from(
+            &Args::parse_from(gen_args(vec!["file.md"]), &config),
+            config::Config::default()
+        ),
         Opts {
             file_path: PathBuf::from("file.md"),
             theme: ThemeType::default().as_theme(),
             scale: None,
             font_opts: FontOptions::default(),
-            args: Args::default(),
         }
     );
 }
 
 #[test]
 fn config_overrides_default() {
+    let config = config::Config {
+        theme: ThemeType::Dark,
+        ..Default::default()
+    };
     assert_eq!(
         Opts::parse_and_load_from(
-            gen_args(vec!["file.md"]),
-            config::Config {
-                theme: ThemeType::Dark,
-                ..Default::default()
-            }
+            &Args::parse_from(gen_args(vec!["file.md"]), &config),
+            config
         ),
         Opts {
             file_path: PathBuf::from("file.md"),
             theme: ThemeType::Dark.as_theme(),
             scale: None,
             font_opts: FontOptions::default(),
-            args: Args::default(),
         }
     );
+    let config = config::Config {
+        scale: Some(1.5),
+        ..Default::default()
+    };
     assert_eq!(
         Opts::parse_and_load_from(
-            gen_args(vec!["file.md"]),
-            config::Config {
-                scale: Some(1.5),
-                ..Default::default()
-            }
+            &Args::parse_from(gen_args(vec!["file.md"]), &config),
+            config,
         ),
         Opts {
             file_path: PathBuf::from("file.md"),
             theme: ThemeType::default().as_theme(),
             scale: Some(1.5),
             font_opts: FontOptions::default(),
-            args: Args::default(),
         }
     );
 }
 
 #[test]
 fn from_cli() {
+    let config = config::Config::default();
     assert_eq!(
         Opts::parse_and_load_from(
-            gen_args(vec!["--theme", "dark", "file.md"]),
+            &Args::parse_from(gen_args(vec!["--theme", "dark", "file.md"]), &config),
             config::Config::default()
         ),
         Opts {
@@ -83,26 +87,25 @@ fn from_cli() {
             theme: ThemeType::Dark.as_theme(),
             scale: None,
             font_opts: FontOptions::default(),
-            args: Args::default(),
         }
     );
 
     // CLI takes precedence over config
+    let config = config::Config {
+        theme: ThemeType::Dark,
+        scale: Some(0.1),
+        ..Default::default()
+    };
     assert_eq!(
         Opts::parse_and_load_from(
-            gen_args(vec!["--scale", "1.5", "file.md"]),
-            config::Config {
-                theme: ThemeType::Dark,
-                scale: Some(0.1),
-                ..Default::default()
-            },
+            &Args::parse_from(gen_args(vec!["--scale", "1.5", "file.md"]), &config),
+            config
         ),
         Opts {
             file_path: PathBuf::from("file.md"),
             theme: ThemeType::Dark.as_theme(),
             scale: Some(1.5),
             font_opts: FontOptions::default(),
-            args: Args::default(),
         }
     );
 }


### PR DESCRIPTION
Allows for inline to spawn a new instance of itself along with the same command line arguments in order to preview markdown files that are linked with a relative path.