### PR TITLE
Give me window resizes or give me death

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -219,8 +219,6 @@ impl Inlyne {
                 None => return,
             };
 
-            println!("{event:?}");
-
             match event {
                 RelevantEvent::UserEvent(inlyne_event) => match inlyne_event {
                     InlyneEvent::Reposition => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -382,7 +382,7 @@ impl Inlyne {
                     _ => {}
                 },
                 Event::MainEventsCleared => {
-                    if let Some(size) = pending_resize {
+                    if let Some(size) = pending_resize.take() {
                         self.renderer.config.width = size.width;
                         self.renderer.config.height = size.height;
                         self.renderer.positioner.screen_size = size.into();
@@ -390,7 +390,7 @@ impl Inlyne {
                             .surface
                             .configure(&self.renderer.device, &self.renderer.config);
                         self.renderer.reposition(&mut self.elements);
-                        pending_resize = None;
+                        self.renderer.set_scroll_y(self.renderer.scroll_y);
                         self.window.request_redraw();
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ use winit::event::ModifiersState;
 use winit::event::VirtualKeyCode;
 use winit::event::{ElementState, MouseButton};
 use winit::{
-    event::{Event, MouseScrollDelta, WindowEvent},
+    dpi::{PhysicalPosition, PhysicalSize},
+    event::{Event, KeyboardInput, MouseScrollDelta, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::{CursorIcon, Window},
 };
@@ -43,6 +44,59 @@ use std::sync::Mutex;
 #[derive(Debug)]
 pub enum InlyneEvent {
     Reposition,
+}
+
+/// All the `winit::event::Event`s that we care about
+#[derive(Debug)]
+enum RelevantEvent {
+    UserEvent(InlyneEvent),
+    WindowResized(PhysicalSize<u32>),
+    RedrawRequested,
+    CloseRequested,
+    MouseWheel(MouseScrollDelta),
+    CursorMoved(PhysicalPosition<f64>),
+    LmbPressed,
+    LmbReleased,
+    ModifiersChanged(ModifiersState),
+    KeyPressed(VirtualKeyCode),
+}
+
+impl RelevantEvent {
+    fn new(event: Event<'_, InlyneEvent>) -> Option<RelevantEvent> {
+        match event {
+            Event::UserEvent(inlyne_event) => Some(Self::UserEvent(inlyne_event)),
+            Event::WindowEvent {
+                event: WindowEvent::Resized(size),
+                ..
+            } => Some(Self::WindowResized(size)),
+            Event::RedrawRequested(_) => Some(Self::RedrawRequested),
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => Some(Self::CloseRequested),
+                WindowEvent::MouseWheel { delta, .. } => Some(Self::MouseWheel(delta)),
+                WindowEvent::CursorMoved { position, .. } => Some(Self::CursorMoved(position)),
+                WindowEvent::MouseInput {
+                    state,
+                    button: MouseButton::Left,
+                    ..
+                } => match state {
+                    ElementState::Pressed => Some(Self::LmbPressed),
+                    ElementState::Released => Some(Self::LmbReleased),
+                },
+                WindowEvent::ModifiersChanged(state) => Some(Self::ModifiersChanged(state)),
+                WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            state: ElementState::Pressed,
+                            virtual_keycode: Some(keycode),
+                            ..
+                        },
+                    ..
+                } => Some(Self::KeyPressed(keycode)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
 }
 
 pub enum Hoverable<'a> {
@@ -125,19 +179,22 @@ impl Inlyne {
         let mut modifiers = ModifiersState::empty();
         let mut last_loc = (0.0, 0.0);
         let event_loop_proxy = self.event_loop.create_proxy();
-        self.event_loop.run(move |event, _, control_flow| {
+        self.event_loop.run(move |winit_event, _, control_flow| {
             *control_flow = ControlFlow::Wait;
+
+            let event = match RelevantEvent::new(winit_event) {
+                Some(event) => event,
+                None => return,
+            };
+
             match event {
-                Event::UserEvent(inlyne_event) => match inlyne_event {
+                RelevantEvent::UserEvent(inlyne_event) => match inlyne_event {
                     InlyneEvent::Reposition => {
                         self.renderer.reposition(&mut self.elements);
                         self.window.request_redraw()
                     }
                 },
-                Event::WindowEvent {
-                    event: WindowEvent::Resized(size),
-                    ..
-                } => {
+                RelevantEvent::WindowResized(size) => {
                     self.renderer.config.width = size.width;
                     self.renderer.config.height = size.height;
                     self.renderer.positioner.screen_size = size.into();
@@ -147,7 +204,7 @@ impl Inlyne {
                     self.renderer.reposition(&mut self.elements);
                     self.window.request_redraw();
                 }
-                Event::RedrawRequested(_) => {
+                RelevantEvent::RedrawRequested => {
                     let queue = {
                         self.element_queue
                             .try_lock()
@@ -182,169 +239,147 @@ impl Inlyne {
                         .with_context(|| "Renderer failed to redraw the screen")
                         .unwrap();
                 }
-                Event::WindowEvent { event, .. } => match event {
-                    WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
-                    WindowEvent::MouseWheel { delta, .. } => {
-                        let y_pixel_shift = match delta {
-                            MouseScrollDelta::PixelDelta(pos) => {
-                                pos.y as f32 * self.renderer.hidpi_scale * self.renderer.zoom
-                            }
-                            // Arbitrarily pick x30 as the number of pixels to shift per line
-                            MouseScrollDelta::LineDelta(_, y_delta) => {
-                                y_delta as f32
-                                    * 32.0
-                                    * self.renderer.hidpi_scale
-                                    * self.renderer.zoom
-                            }
-                        };
+                RelevantEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                RelevantEvent::MouseWheel(delta) => {
+                    let y_pixel_shift = match delta {
+                        MouseScrollDelta::PixelDelta(pos) => {
+                            pos.y as f32 * self.renderer.hidpi_scale * self.renderer.zoom
+                        }
+                        // Arbitrarily pick x30 as the number of pixels to shift per line
+                        MouseScrollDelta::LineDelta(_, y_delta) => {
+                            y_delta as f32 * 32.0 * self.renderer.hidpi_scale * self.renderer.zoom
+                        }
+                    };
 
-                        self.renderer
-                            .set_scroll_y(self.renderer.scroll_y - y_pixel_shift);
+                    self.renderer
+                        .set_scroll_y(self.renderer.scroll_y - y_pixel_shift);
+                    self.window.request_redraw();
+                }
+                RelevantEvent::CursorMoved(position) => {
+                    let screen_size = self.renderer.screen_size();
+                    let loc = (
+                        position.x as f32,
+                        position.y as f32 + self.renderer.scroll_y,
+                    );
+                    last_loc = loc;
+
+                    let cursor_icon = if let Some(hoverable) = Self::find_hoverable(
+                        &self.elements,
+                        &mut self.renderer.glyph_brush,
+                        loc,
+                        screen_size,
+                        self.renderer.zoom,
+                    ) {
+                        match hoverable {
+                            Hoverable::Image(Image { is_link: None, .. }) => CursorIcon::Default,
+                            Hoverable::Text(Text { link: None, .. }) => CursorIcon::Text,
+                            _some_link => CursorIcon::Hand,
+                        }
+                    } else {
+                        CursorIcon::Default
+                    };
+                    self.window.set_cursor_icon(cursor_icon);
+
+                    if scrollbar_held
+                        || (Rect::new((screen_size.0 - 25., 0.), (25., screen_size.1))
+                            .contains(position.into())
+                            && mouse_down)
+                    {
+                        let target_scroll = ((position.y as f32 / screen_size.1)
+                            * self.renderer.positioner.reserved_height)
+                            - (screen_size.1 / self.renderer.positioner.reserved_height
+                                * screen_size.1);
+                        self.renderer.set_scroll_y(target_scroll);
+                        self.window.request_redraw();
+                        if !scrollbar_held {
+                            scrollbar_held = true;
+                        }
+                    } else if let Some(selection) = &mut self.renderer.selection {
+                        if mouse_down {
+                            selection.1 = loc;
+                            self.window.request_redraw();
+                        }
+                    }
+                }
+                RelevantEvent::LmbPressed => {
+                    // Reset selection
+                    if self.renderer.selection.is_some() {
+                        self.renderer.selection = None;
                         self.window.request_redraw();
                     }
-                    WindowEvent::CursorMoved { position, .. } => {
-                        let screen_size = self.renderer.screen_size();
-                        let loc = (
-                            position.x as f32,
-                            position.y as f32 + self.renderer.scroll_y,
-                        );
-                        last_loc = loc;
 
-                        let cursor_icon = if let Some(hoverable) = Self::find_hoverable(
-                            &self.elements,
-                            &mut self.renderer.glyph_brush,
-                            loc,
-                            screen_size,
-                            self.renderer.zoom,
-                        ) {
-                            match hoverable {
-                                Hoverable::Image(Image { is_link: None, .. }) => {
-                                    CursorIcon::Default
-                                }
-                                Hoverable::Text(Text { link: None, .. }) => CursorIcon::Text,
-                                _some_link => CursorIcon::Hand,
-                            }
-                        } else {
-                            CursorIcon::Default
+                    // Try to click a link
+                    let screen_size = self.renderer.screen_size();
+                    if let Some(hoverable) = Self::find_hoverable(
+                        &self.elements,
+                        &mut self.renderer.glyph_brush,
+                        last_loc,
+                        screen_size,
+                        self.renderer.zoom,
+                    ) {
+                        let maybe_link = match hoverable {
+                            Hoverable::Image(Image { is_link, .. }) => is_link,
+                            Hoverable::Text(Text { link, .. }) => link,
                         };
-                        self.window.set_cursor_icon(cursor_icon);
 
-                        if scrollbar_held
-                            || (Rect::new((screen_size.0 - 25., 0.), (25., screen_size.1))
-                                .contains(position.into())
-                                && mouse_down)
-                        {
-                            let target_scroll = ((position.y as f32 / screen_size.1)
-                                * self.renderer.positioner.reserved_height)
-                                - (screen_size.1 / self.renderer.positioner.reserved_height
-                                    * screen_size.1);
-                            self.renderer.set_scroll_y(target_scroll);
-                            self.window.request_redraw();
-                            if !scrollbar_held {
-                                scrollbar_held = true;
+                        if let Some(link) = maybe_link {
+                            if open::that(link).is_err() {
+                                if let Some(anchor_pos) = self.renderer.positioner.anchors.get(link)
+                                {
+                                    self.renderer.set_scroll_y(*anchor_pos);
+                                    self.window.request_redraw();
+                                    self.window.set_cursor_icon(CursorIcon::Default);
+                                }
                             }
-                        } else if let Some(selection) = &mut self.renderer.selection {
-                            if mouse_down {
-                                selection.1 = loc;
-                                self.window.request_redraw();
-                            }
+                        } else if self.renderer.selection.is_none() {
+                            // Only set selection when not over link
+                            self.renderer.selection = Some((last_loc, last_loc));
+                        }
+                    } else if self.renderer.selection.is_none() {
+                        self.renderer.selection = Some((last_loc, last_loc));
+                    }
+
+                    mouse_down = true;
+                }
+                RelevantEvent::LmbReleased => {
+                    scrollbar_held = false;
+                    mouse_down = false;
+                }
+                RelevantEvent::ModifiersChanged(new_state) => modifiers = new_state,
+                RelevantEvent::KeyPressed(keycode) => match keycode {
+                    VirtualKeyCode::C => {
+                        let copy = (cfg!(target_os = "macos") && modifiers.logo())
+                            || (!cfg!(target_os = "macos") && modifiers.ctrl());
+                        if copy {
+                            self.clipboard
+                                .set_contents(self.renderer.selection_text.trim().to_owned())
+                                .unwrap()
                         }
                     }
-                    WindowEvent::MouseInput {
-                        state,
-                        button: MouseButton::Left,
-                        ..
-                    } => match state {
-                        ElementState::Pressed => {
-                            // Reset selection
-                            if self.renderer.selection.is_some() {
-                                self.renderer.selection = None;
-                                self.window.request_redraw();
-                            }
-
-                            // Try to click a link
-                            let screen_size = self.renderer.screen_size();
-                            if let Some(hoverable) = Self::find_hoverable(
-                                &self.elements,
-                                &mut self.renderer.glyph_brush,
-                                last_loc,
-                                screen_size,
-                                self.renderer.zoom,
-                            ) {
-                                let maybe_link = match hoverable {
-                                    Hoverable::Image(Image { is_link, .. }) => is_link,
-                                    Hoverable::Text(Text { link, .. }) => link,
-                                };
-
-                                if let Some(link) = maybe_link {
-                                    if open::that(link).is_err() {
-                                        if let Some(anchor_pos) =
-                                            self.renderer.positioner.anchors.get(link)
-                                        {
-                                            self.renderer.set_scroll_y(*anchor_pos);
-                                            self.window.request_redraw();
-                                            self.window.set_cursor_icon(CursorIcon::Default);
-                                        }
-                                    }
-                                } else if self.renderer.selection.is_none() {
-                                    // Only set selection when not over link
-                                    self.renderer.selection = Some((last_loc, last_loc));
-                                }
-                            } else if self.renderer.selection.is_none() {
-                                self.renderer.selection = Some((last_loc, last_loc));
-                            }
-
-                            mouse_down = true;
+                    VirtualKeyCode::Equals => {
+                        let zoom = ((cfg!(target_os = "macos") && modifiers.logo())
+                            || (!cfg!(target_os = "macos") && modifiers.ctrl()))
+                            && modifiers.shift();
+                        if zoom {
+                            self.renderer.zoom *= 1.1;
+                            self.renderer.reposition(&mut self.elements);
+                            self.renderer.set_scroll_y(self.renderer.scroll_y);
+                            self.window.request_redraw();
                         }
-                        ElementState::Released => {
-                            scrollbar_held = false;
-                            mouse_down = false;
-                        }
-                    },
-                    WindowEvent::ModifiersChanged(modifier_state) => modifiers = modifier_state,
-                    WindowEvent::KeyboardInput { input, .. } => {
-                        if let ElementState::Pressed = input.state {
-                            match input.virtual_keycode {
-                                Some(VirtualKeyCode::C) => {
-                                    let copy = (cfg!(target_os = "macos") && modifiers.logo())
-                                        || (!cfg!(target_os = "macos") && modifiers.ctrl());
-                                    if copy {
-                                        self.clipboard
-                                            .set_contents(
-                                                self.renderer.selection_text.trim().to_owned(),
-                                            )
-                                            .unwrap()
-                                    }
-                                }
-                                Some(VirtualKeyCode::Equals) => {
-                                    let zoom = ((cfg!(target_os = "macos") && modifiers.logo())
-                                        || (!cfg!(target_os = "macos") && modifiers.ctrl()))
-                                        && modifiers.shift();
-                                    if zoom {
-                                        self.renderer.zoom *= 1.1;
-                                        self.renderer.reposition(&mut self.elements);
-                                        self.renderer.set_scroll_y(self.renderer.scroll_y);
-                                        self.window.request_redraw();
-                                    }
-                                }
-                                Some(VirtualKeyCode::Minus) => {
-                                    let zoom = ((cfg!(target_os = "macos") && modifiers.logo())
-                                        || (!cfg!(target_os = "macos") && modifiers.ctrl()))
-                                        && modifiers.shift();
-                                    if zoom {
-                                        self.renderer.zoom *= 0.9;
-                                        self.renderer.reposition(&mut self.elements);
-                                        self.renderer.set_scroll_y(self.renderer.scroll_y);
-                                        self.window.request_redraw();
-                                    }
-                                }
-                                _ => {}
-                            }
+                    }
+                    VirtualKeyCode::Minus => {
+                        let zoom = ((cfg!(target_os = "macos") && modifiers.logo())
+                            || (!cfg!(target_os = "macos") && modifiers.ctrl()))
+                            && modifiers.shift();
+                        if zoom {
+                            self.renderer.zoom *= 0.9;
+                            self.renderer.reposition(&mut self.elements);
+                            self.renderer.set_scroll_y(self.renderer.scroll_y);
+                            self.window.request_redraw();
                         }
                     }
                     _ => {}
                 },
-                _ => {}
             }
         });
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -146,6 +146,7 @@ impl Renderer {
         let image_renderer = ImageRenderer::new(&device, &swapchain_format);
 
         let glyph_brush = GlyphBrushBuilder::using_fonts(fonts::get_fonts(font_opts)?)
+            .draw_cache_position_tolerance(0.5)
             .build(&device, swapchain_format);
 
         let lyon_buffer: VertexBuffers<Vertex, u16> = VertexBuffers::new();


### PR DESCRIPTION
Resolves #25 

The comment linked below covers things pretty well. The gist is that we can lazily handle window resizing since we will get a `RedrawRequested` afterwards. This prevents a bunch of `WindowResized`s from clogging up the event queue

https://github.com/trimental/inlyne/compare/main...LovecraftianHorror:give-me-window-resizes-or-give-me-death?expand=1#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR191-R216