### PR TITLE
Add initial inline image support

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -157,15 +157,15 @@ impl TextBox {
         for (glyph_bounds, glyph) in self.glyph_bounds(glyph_brush, screen_position, bounds, zoom) {
             if self.texts[glyph.section_index].is_underlined {
                 lines.push((
-                    (glyph_bounds.pos.0, glyph_bounds.max.1),
-                    (glyph_bounds.max.0, glyph_bounds.max.1),
+                    (glyph_bounds.pos.0, glyph_bounds.max().1),
+                    (glyph_bounds.max().0, glyph_bounds.max().1),
                 ));
             }
             if self.texts[glyph.section_index].is_striked {
                 let mid_height = glyph_bounds.pos.1 + glyph_bounds.size.1 / 2.;
                 lines.push((
                     (glyph_bounds.pos.0, mid_height),
-                    (glyph_bounds.max.0, mid_height),
+                    (glyph_bounds.max().0, mid_height),
                 ));
             }
         }
@@ -194,14 +194,14 @@ impl TextBox {
             for (glyph_bounds, glyph) in
                 self.glyph_bounds(glyph_brush, screen_position, bounds, zoom)
             {
-                if (glyph_bounds.pos.1 >= selection.0 .1 && glyph_bounds.max.1 <= selection.1 .1)
-                    || (glyph_bounds.max.1 <= selection.1 .1
-                        && glyph_bounds.max.1 >= selection.0 .1
-                        && glyph_bounds.max.0 >= selection.0 .0)
-                    || (glyph_bounds.max.1 >= selection.1 .1
+                if (glyph_bounds.pos.1 >= selection.0 .1 && glyph_bounds.max().1 <= selection.1 .1)
+                    || (glyph_bounds.max().1 <= selection.1 .1
+                        && glyph_bounds.max().1 >= selection.0 .1
+                        && glyph_bounds.max().0 >= selection.0 .0)
+                    || (glyph_bounds.max().1 >= selection.1 .1
                         && glyph_bounds.pos.1 <= selection.0 .1
                         && glyph_bounds.pos.0 <= selection.0 .0.max(selection.1 .0)
-                        && glyph_bounds.max.0 >= selection.0 .0.min(selection.1 .0))
+                        && glyph_bounds.max().0 >= selection.0 .0.min(selection.1 .0))
                 {
                     selection_rects.push(glyph_bounds);
                     if let Some(char) = self.texts[glyph.section_index]
@@ -216,7 +216,7 @@ impl TextBox {
             selection_text.push('\n');
         }
         if rect.pos.1 >= selection.0 .1.min(selection.1 .1)
-            && rect.max.1 <= selection.0 .1.max(selection.1 .1)
+            && rect.max().1 <= selection.0 .1.max(selection.1 .1)
         {
             selection_rects.push(rect.clone());
             for text in &self.texts {
@@ -228,7 +228,7 @@ impl TextBox {
             for (glyph_bounds, glyph) in
                 self.glyph_bounds(glyph_brush, screen_position, bounds, zoom)
             {
-                if (glyph_bounds.pos.1 >= selection.0 .1 && glyph_bounds.max.1 <= selection.1 .1)
+                if (glyph_bounds.pos.1 >= selection.0 .1 && glyph_bounds.max().1 <= selection.1 .1)
                     || (glyph_bounds.pos.1 <= selection.1 .1
                         && glyph_bounds.pos.1 >= selection.0 .1
                         && glyph_bounds.pos.0 <= selection.1 .0)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,28 +5,26 @@ use winit::window::CursorIcon;
 pub struct Rect {
     pub pos: (f32, f32),
     pub size: (f32, f32),
-    pub max: (f32, f32),
 }
 
 impl Rect {
     pub fn new(pos: (f32, f32), size: (f32, f32)) -> Rect {
-        Rect {
-            pos,
-            size,
-            max: (pos.0 + size.0, pos.1 + size.1),
-        }
+        Rect { pos, size }
     }
 
     pub fn from_min_max(min: (f32, f32), max: (f32, f32)) -> Rect {
         Rect {
             pos: min,
             size: (max.0 - min.0, max.1 - min.1),
-            max,
         }
     }
 
+    pub fn max(&self) -> (f32, f32) {
+        (self.pos.0 + self.size.0, self.pos.1 + self.size.1)
+    }
+
     pub fn contains(&self, loc: (f32, f32)) -> bool {
-        self.pos.0 <= loc.0 && loc.0 <= self.max.0 && self.pos.1 <= loc.1 && loc.1 <= self.max.1
+        self.pos.0 <= loc.0 && loc.0 <= self.max().0 && self.pos.1 <= loc.1 && loc.1 <= self.max().1
     }
 }
 
@@ -40,7 +38,7 @@ impl From<ab_glyph::Rect> for Rect {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum Align {
     #[default]
     Left,


### PR DESCRIPTION
Adds initial inline image support by implementing a new `Row` element type (exciting 🤯 🎊). I was expecting horizontal positioning to be more of a challenge, although granted I haven't searched too deeply for bugs yet. 

Hopefully this solves https://github.com/trimental/inlyne/issues/17. Interested in @LovecraftianHorror opinion on this PR and whether it solves his issue in a nice enough way.

Here's a beautiful image to really sell the PR!

<img width="912" alt="Screenshot 2022-08-21 at 4 37 24 am" src="https://user-images.githubusercontent.com/40879396/185765201-84238199-5aa1-4ed7-9ac8-788691e1112e.png">

