### PR TITLE
Font optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,7 +852,7 @@ checksum = "122fa73a5566372f9df09768a16e8e3dad7ad18abe07835f1f0b71f84078ba4c"
 dependencies = [
  "fontconfig-parser",
  "log",
- "memmap2 0.5.6",
+ "memmap2 0.5.7",
  "ttf-parser",
 ]
 
@@ -1175,6 +1175,7 @@ dependencies = [
  "html5ever",
  "image",
  "lyon",
+ "memmap2 0.5.7",
  "open",
  "pollster",
  "resvg",
@@ -1432,9 +1433,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2e4455be2010e8c5e77f0d10234b30f3a636a5305725609b5a71ad00d22577"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
 ]
@@ -2563,7 +2564,7 @@ dependencies = [
  "dlib",
  "lazy_static",
  "log",
- "memmap2 0.5.6",
+ "memmap2 0.5.7",
  "nix 0.24.2",
  "pkg-config",
  "wayland-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ serde = { version = "1.0.143", features = ["derive"] }
 toml = "0.5.9"
 ureq = { version = "2.5.0", features = ["native-tls"] }
 font-kit = "0.11.0"
+memmap2 = "0.5.7"
 
 # Uncomment for profiling
 # [profile.release]

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -8,7 +8,6 @@ use font_kit::family_name::FamilyName;
 use font_kit::handle::Handle;
 use font_kit::properties::{Properties, Style, Weight};
 use font_kit::source::SystemSource;
-use font_kit::sources::fontconfig::FontconfigSource;
 use serde::{Deserialize, Serialize};
 use wgpu_glyph::ab_glyph::{FontArc, FontRef, FontVec};
 
@@ -175,7 +174,7 @@ fn load_cached_fonts_by_name(desired_name: &str, path: &Path) -> Option<Vec<Font
 }
 
 fn select_best_font(
-    source: &FontconfigSource,
+    source: &SystemSource,
     name: &[FamilyName],
     props: &Properties,
 ) -> anyhow::Result<Handle> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -145,7 +145,7 @@ impl Renderer {
         surface.configure(&device, &config);
         let image_renderer = ImageRenderer::new(&device, &swapchain_format);
 
-        let glyph_brush = GlyphBrushBuilder::using_fonts(fonts::get_fonts(font_opts)?)
+        let glyph_brush = GlyphBrushBuilder::using_fonts(fonts::get_fonts(&font_opts)?)
             .build(&device, swapchain_format);
 
         let lyon_buffer: VertexBuffers<Vertex, u16> = VertexBuffers::new();


### PR DESCRIPTION
> I think I see a way that things can be sped up, but I won't have time to try hacking things together till this weekend

Well I mentioned it before so here I am!

This PR involves two changes to improve performance with fonts in both the time to select them and the amount of memory usage used when loading them

1. Cache the matches when specifying a custom font family
2. Memmap the font files to avoid loading them fully into memory

## Caching the matches

This involved a bit more spaghetti logic than I wanted, but there was a lot of trying things based on if the cache exists, falling back, and resetting the cache involved which ends up looking a little messy. The basic idea is that we store the results returned by `.select_best_match()` when a custom font family is specified in `inlyne.toml`. These get stored in `<cache_dir>/inlyne/font_regular.toml` and `<cache_dir>/inlyne/font_mono.toml`. They end up looking something like this

```toml
name = "Iosevka"

[base]
path = "/usr/share/fonts/TTF/iosevka-regular.ttc"
font_index = 0

[italic]
path = "/usr/share/fonts/TTF/iosevka-regular.ttc"
font_index = 7

[bold]
path = "/usr/share/fonts/TTF/Iosevka Bold Nerd Font Complete.ttf"
font_index = 0

[bold_italic]
path = "/usr/share/fonts/TTF/Iosevka Bold Italic Nerd Font Complete Mono.ttf"
font_index = 0
```

When the cached file exists and the same family name is provided it will try to load the fonts from the cached path and index. If the cache is invalid or the name is different than the one stored then this gracefully falls back to `.select_best_match()` again

This allows us to avoid the potentially long `.select_best_match()` times that occur on some fonts

## Memmapping the font files

This one certainly has a lot of spookiness in one block

```rust
Handle::Path { path, font_index } => {
    let file = fs::File::open(path)?;
    // Font files can be big. Memmap and leak the font file to avoid keeping it in memory.
    // Because we load 8 font files this will leak exactly 8 * 16 = 128 bytes
    // SAFETY: This is safe as long as nothing (either in or outside of this program)
    // modifies the file while it's memmapped. Unfortunately there is nothing we can do to
    // guarantee this won't happen, but memmapping font files is a common practice
    let mmap = unsafe { memmap2::Mmap::map(&file)? };
    let leaked = Box::leak(Box::new(mmap));
    Ok(FontArc::from(FontRef::try_from_slice_and_index(
        leaked, font_index,
    )?))
}
```

I think the comment describes the _why_ pretty well with the gist being that memmapping and leaking the file means that we can avoid loading the full file into memory. This does mean we have a memory leak, but it's consistently 128 bytes (well `Mmap`'s size is probably system dependent, but I'd imagine it's always in the same ballpark) to avoid loading potentially MBs of font files into memory

## Motivation

I use _Iosevka Nerd Font_ for my monospace font. The font files for this font are pretty beefy (the two `.ttc` files in the cache example above are both 28 MiB) which leads to both bad `.select_best_match()` runtime _and_ high memory usage (well higher than I would expect) from having them loaded into memory. Let's take a look at some numbers

| Situation | `get_fonts()` duration |
| :---: | :---: |
| `main` | 908ms |
| This PR (w/o cache) | 898ms |
| This PR (w/ cache) | 24ms :tada: |

_Peak memory usage w/ loading `src/test_data/bun.md`_

| Situation | Mem usage |
| :---: | :---: |
| Before | 224MB |
| After | 168MB |

(The vast majority of peak memory usage when viewing `bun.md` for me now is from the image files getting loaded into memory which is what I would expect. Loading `inlyne`s README had a peak memory usage of 16MB for me :partying_face: )