### PR TITLE
Add initial logging support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,6 +1120,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,9 +1190,11 @@ dependencies = [
  "comrak",
  "copypasta",
  "dirs",
+ "env_logger",
  "font-kit",
  "html5ever",
  "image",
+ "log",
  "lyon",
  "open",
  "pollster",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ serde = { version = "1.0.143", features = ["derive"] }
 toml = "0.5.9"
 ureq = { version = "2.5.0", features = ["native-tls"] }
 font-kit = "0.11.0"
+log = "0.4.17"
+env_logger = "0.9.0"
 
 # Uncomment for profiling
 # [profile.release]

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,12 +449,17 @@ impl Inlyne {
 }
 
 fn main() -> anyhow::Result<()> {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Error)
+        .filter_module("inlyne", log::LevelFilter::Info)
+        .parse_env("INLYNE_LOG")
+        .init();
+
     let config = match Config::load() {
         Ok(config) => config,
         Err(err) => {
-            // TODO: switch to logging
-            eprintln!(
-                "WARN: Failed reading config file. Falling back to defaults. Error: {}",
+            log::warn!(
+                "Failed reading config file. Falling back to defaults. Error: {}",
                 err
             );
             Config::default()


### PR DESCRIPTION
I opted for `env_logger` since I like the filtering options it provides, but I would be open to alternatives (I also like `tracing-subscriber`)

The env var for filtering is `INLYNE_LOG`. By default dependencies only show `Error`s while `inlyne` shows `Info` and up to keep the default output from being very noisy