### PR TITLE
Avoid copying image data when possible

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -129,7 +129,7 @@ impl Image {
 
             if let Ok(image) = image::load_from_memory(&image_data) {
                 *(image_clone.lock().unwrap()) = Some(ImageData {
-                    rgba_image: image.to_rgba8(),
+                    rgba_image: image.into_rgba8(),
                     scale: true,
                 });
             } else {


### PR DESCRIPTION
Tiny little change

Some of the raw image data can be pretty big (the largest image in bun's README is 55 MiB raw). This tiny change avoids copying the image data if the `DynamicImage` is already in the rgba8 format. This lowers the peak memory usage of loading bun's README by 55 MiB