### PR TITLE
Allow for customizing lines scrolled

### DIFF
--- a/inlyne.toml.sample
+++ b/inlyne.toml.sample
@@ -7,6 +7,11 @@
 # # Possible values: ["Light", "Dark"]
 # theme = "Dark"
 
+# # Number of lines to scroll when using a line-based scrolling device (a lot of
+# # mice)
+# # Default: 3.0
+# lines-to-scroll = 4.5
+
 # # The light and dark themes can be customized as well
 # # Here is a dark theme inspired by GitHub's dark dimmed theme
 # [dark-theme]

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ pub struct Inlyne {
     element_queue: Arc<Mutex<VecDeque<Element>>>,
     clipboard: ClipboardContext,
     elements: Vec<Positioned<Element>>,
+    lines_to_scroll: f32,
     args: Args,
 }
 
@@ -160,6 +161,7 @@ impl Inlyne {
             element_queue: Arc::new(Mutex::new(VecDeque::new())),
             clipboard,
             elements: Vec::new(),
+            lines_to_scroll: opts.lines_to_scroll,
             args,
         })
     }
@@ -267,10 +269,10 @@ impl Inlyne {
                             MouseScrollDelta::PixelDelta(pos) => {
                                 pos.y as f32 * self.renderer.hidpi_scale * self.renderer.zoom
                             }
-                            // Arbitrarily pick x30 as the number of pixels to shift per line
                             MouseScrollDelta::LineDelta(_, y_delta) => {
                                 y_delta as f32
-                                    * 32.0
+                                    * 16.0
+                                    * self.lines_to_scroll
                                     * self.renderer.hidpi_scale
                                     * self.renderer.zoom
                             }

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -67,12 +67,23 @@ impl OptionalTheme {
     }
 }
 
+#[derive(Deserialize, Debug)]
+pub struct LinesToScroll(pub f32);
+
+impl Default for LinesToScroll {
+    fn default() -> Self {
+        Self(3.0)
+    }
+}
+
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
     #[serde(default)]
     pub theme: ThemeType,
     pub scale: Option<f32>,
+    #[serde(default)]
+    pub lines_to_scroll: LinesToScroll,
     pub light_theme: Option<OptionalTheme>,
     pub dark_theme: Option<OptionalTheme>,
     pub font_options: Option<FontOptions>,

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -25,6 +25,7 @@ pub struct Opts {
     pub file_path: PathBuf,
     pub theme: color::Theme,
     pub scale: Option<f32>,
+    pub lines_to_scroll: f32,
     pub font_opts: FontOptions,
 }
 
@@ -33,6 +34,7 @@ impl Opts {
         let config::Config {
             theme: config_theme,
             scale: config_scale,
+            lines_to_scroll: config_lines_to_scroll,
             light_theme: config_light_theme,
             dark_theme: config_dark_theme,
             font_options: config_font_options,
@@ -55,6 +57,7 @@ impl Opts {
             file_path: args.file_path.clone(),
             theme,
             scale: args.scale.or(config_scale),
+            lines_to_scroll: config_lines_to_scroll.0,
             font_opts,
         }
     }


### PR DESCRIPTION
Resolves #13 

This PR adjusts the default number of lines to scroll by to 3, and allows for setting a custom value with the `lines-to-scroll` field in `inlyne.toml`