### PR TITLE
Add details and summary support (hidden text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ self.glyph_brush.queue(&text_box.glyph_section(*pos, bounds));
 - [x] Watch Game of Thrones
 - [ ] Feed the cat
 
+#### Hideable sections
+<details>
+<summary>Click me to show text</summary>
+
+You weren't suppost to see this!
+</details>
+
 #### Alignment
 <p align="left">Text/Image..</p>
 <p align="center">alignment..</p>

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -181,7 +181,6 @@ impl HtmlInterpreter {
                 tok.sink.current_textbox = TextBox::new(Vec::new(), tok.sink.hidpi_scale);
                 tok.sink.stopped = false;
                 let htmlified = markdown_to_html_with_plugins(&md_string, &options, &plugins);
-                println!("{}", &htmlified);
 
                 input.push_back(
                     Tendril::from_str(&htmlified)
@@ -242,7 +241,6 @@ impl HtmlInterpreter {
                     }
                 });
                 if let Some(section) = section {
-                    dbg!("hello");
                     section
                         .elements
                         .push(Positioned::new(self.current_textbox.clone().into()));
@@ -666,7 +664,6 @@ impl TokenSink for HtmlInterpreter {
                                 if let html::Element::Details(ref mut section) = element {
                                     *section.summary =
                                         Some(Positioned::new(self.current_textbox.clone().into()));
-                                    dbg!(&section.elements);
                                     self.current_textbox.texts.clear();
                                     break;
                                 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -3,6 +3,7 @@ use crate::image::Image;
 use crate::image::ImageSize;
 use crate::positioner::Positioned;
 use crate::positioner::Row;
+use crate::positioner::Section;
 use crate::positioner::Spacer;
 use crate::positioner::DEFAULT_MARGIN;
 use crate::table::Table;
@@ -34,7 +35,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 mod html {
-    use crate::{table::Table, text::TextBox, utils::Align};
+    use crate::{positioner::Section, table::Table, text::TextBox, utils::Align};
 
     pub enum HeaderType {
         H1,
@@ -96,6 +97,8 @@ mod html {
         Header(Header),
         Paragraph(Option<Align>),
         Div(Option<Align>),
+        Details(Section),
+        Summary,
     }
 }
 
@@ -178,6 +181,7 @@ impl HtmlInterpreter {
                 tok.sink.current_textbox = TextBox::new(Vec::new(), tok.sink.hidpi_scale);
                 tok.sink.stopped = false;
                 let htmlified = markdown_to_html_with_plugins(&md_string, &options, &plugins);
+                println!("{}", &htmlified);
 
                 input.push_back(
                     Tendril::from_str(&htmlified)
@@ -230,7 +234,21 @@ impl HtmlInterpreter {
             }
             if !empty {
                 self.current_textbox.indent = self.state.global_indent;
-                self.push_element(self.current_textbox.clone().into());
+                let section = self.state.element_stack.iter_mut().rev().find_map(|e| {
+                    if let html::Element::Details(section) = e {
+                        Some(section)
+                    } else {
+                        None
+                    }
+                });
+                if let Some(section) = section {
+                    dbg!("hello");
+                    section
+                        .elements
+                        .push(Positioned::new(self.current_textbox.clone().into()));
+                } else {
+                    self.push_element(self.current_textbox.clone().into());
+                }
             }
         }
         self.current_textbox = TextBox::new(Vec::new(), self.hidpi_scale);
@@ -510,6 +528,19 @@ impl TokenSink for HtmlInterpreter {
                                 }
                             }
                         }
+                        "details" => {
+                            self.push_current_textbox();
+                            self.push_spacer();
+                            let section = Section::new(None, vec![], self.hidpi_scale);
+                            *section.hidden.borrow_mut() = true;
+                            self.state
+                                .element_stack
+                                .push(html::Element::Details(section));
+                        }
+                        "summary" => {
+                            self.push_current_textbox();
+                            self.state.element_stack.push(html::Element::Summary);
+                        }
                         _ => {}
                     },
                     TagKind::EndTag => match tag_name.as_str() {
@@ -621,6 +652,27 @@ impl TokenSink for HtmlInterpreter {
                             }
                         }
                         "span" => self.state.span_color = self.theme.code_color,
+                        "details" => {
+                            self.push_current_textbox();
+                            if let Some(html::Element::Details(section)) =
+                                self.state.element_stack.pop()
+                            {
+                                self.push_element(section.into());
+                            }
+                            self.push_spacer();
+                        }
+                        "summary" => {
+                            for element in self.state.element_stack.iter_mut().rev() {
+                                if let html::Element::Details(ref mut section) = element {
+                                    *section.summary =
+                                        Some(Positioned::new(self.current_textbox.clone().into()));
+                                    dbg!(&section.elements);
+                                    self.current_textbox.texts.clear();
+                                    break;
+                                }
+                            }
+                            self.state.element_stack.pop();
+                        }
                         _ => {}
                     },
                 }


### PR DESCRIPTION
Adds support for hidden text through the html details and summary tags. A new rendering element called `Section` was added to help with this which might prove useful in the future as it's basically the vertical version of `Row`. 

A little triangular marker is placed next to the summary text to show the hidden state.
<img width="745" alt="Screenshot 2022-09-02 at 6 46 05 pm" src="https://user-images.githubusercontent.com/40879396/188123528-a3f4f6a4-a21a-4735-b9bb-d4ceaea7144b.png">
