### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cargo build cache
         uses: actions/cache@v3
@@ -30,7 +30,7 @@ jobs:
   check-macos-arm:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cargo build cache
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,19 +40,13 @@ jobs:
       run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        profile: minimal
-        override: true
-        target: ${{ matrix.target }}
-
+        targets: ${{ matrix.target }}
 
     - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --target ${{ matrix.target }} --release --locked
+      run: |
+        cargo build --target ${{ matrix.target }} --release --locked
 
     - name: Build archive
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,15 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            use-cross: false
 
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            use-cross: false
 
           - os: macos-latest
             target: x86_64-apple-darwin
-            use-cross: false
 
           - os: macos-latest
             target: aarch64-apple-darwin
-            use-cross: false
 
     steps:
     - name: Checkout repository
@@ -55,7 +51,6 @@ jobs:
     - name: Build
       uses: actions-rs/cargo@v1
       with:
-        use-cross: ${{ matrix.use-cross }}
         command: build
         args: --target ${{ matrix.target }} --release --locked
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,6 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release --locked
 
-    - name: Strip binary
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-      run: strip target/${{ matrix.target }}/release/inlyne
-
     - name: Build archive
       shell: bash
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4.17"
 env_logger = "0.10.0"
 notify = "5.1.0"
 
+[profile.release]
+strip = true
 # Uncomment for profiling
-# [profile.release]
 # debug = true


### PR DESCRIPTION
Each commit should be pretty self-explanatory

I went ahead and switched away from `actions-rs` actions since they've been unmaintained for a while now and have been spitting out deprecation notices due to using an old Node runtime