### PR TITLE
Use a custom profile for building releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build
       run: |
-        cargo build --target ${{ matrix.target }} --release --locked
+        cargo build --target ${{ matrix.target }} --profile release-lto --locked
 
     - name: Build archive
       shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,11 @@ log = "0.4.17"
 env_logger = "0.10.0"
 notify = "5.1.0"
 
-[profile.release]
-strip = true
 # Uncomment for profiling
+# [profile.release]
 # debug = true
+
+[profile.release-lto]
+inherits = "release"
+strip = true
+lto = true


### PR DESCRIPTION
This creates a custom profile intended for published releases

I toggled on fat lto because it significantly slims down the final binary for me from 18.3 MiB to 15.2 MiB both stripped (probably also speeds things up a chunk too, but it was already pretty fast anyways). I opted for a custom profile because it **significantly** slows down release builds for me (like going from 2m30s to 4m30s for a clean release build on my laptop), so this way it's easy to only use the profile for actual releases