### PR TITLE
Add flag for generating shell completions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,31 @@ jobs:
       shell: bash
       run: |
         staging="inlyne-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}"
+        comp_out="$staging/completions"
+
         mkdir -p "$staging"
+        mkdir -p "$comp_out"
+
         cp {README.md,LICENSE,example.png,inlyne.toml.sample} "$staging/"
+
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           cp "target/${{ matrix.target }}/release/inlyne.exe" "$staging/"
+          inlyne_bin="$staging/inlyne.exe"
+        else
+          cp "target/${{ matrix.target }}/release/inlyne" "$staging/"
+          inlyne_bin="$staging/inlyne"
+        fi
+
+        "$inlyne_bin" --gen-completions bash       > "$comp_out/inlyne.bash"
+        "$inlyne_bin" --gen-completions elvish     > "$comp_out/inlyne.elv"
+        "$inlyne_bin" --gen-completions fish       > "$comp_out/inlyne.fish"
+        "$inlyne_bin" --gen-completions powershell > "$comp_out/inlyne.ps1"
+        "$inlyne_bin" --gen-completions zsh        > "$comp_out/_inlyne"
+
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
           7z a "$staging.zip" "$staging"
           echo "ASSET=$staging.zip" >> $GITHUB_ENV
         else
-          cp "target/${{ matrix.target }}/release/inlyne" "$staging/"
           tar czf "$staging.tar.gz" "$staging"
           echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
         fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c22dcfb410883764b29953103d9ef7bb8fe21b3fa1158bc99986c2067294bd"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1335,6 +1344,7 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "clap",
+ "clap_complete",
  "comrak",
  "copypasta",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ memmap2 = "0.5.10"
 log = "0.4.17"
 env_logger = "0.10.0"
 notify = "5.1.0"
+clap_complete = "4.2.0"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
This adds a flag (`--gen-completions <shell>`) that generates shell completions to stdout. It also changes CI so that all completions _should_ be generated and provided up front (assuming I didn't subtly bork the release CI job)

I can confirm that it works on zsh for me

![image](https://user-images.githubusercontent.com/30302768/228940611-f80647cc-3b2a-4acd-8ace-618ecdc4dcc7.png)