### PR TITLE
Don't detect system theme in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -657,6 +657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "d3d12"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +728,12 @@ name = "deunicode"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1608,6 +1624,7 @@ dependencies = [
  "notify",
  "open",
  "pollster",
+ "pretty_assertions",
  "reqwest",
  "resvg",
  "serde",
@@ -2439,6 +2456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,6 +2718,18 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -4447,6 +4485,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,6 @@ dark-light = "1.0.0"
 inherits = "release"
 strip = true
 lto = true
+
+[dev-dependencies]
+pretty_assertions = "1.3.0"

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -32,20 +32,22 @@ pub struct Args {
     pub scale: Option<f32>,
 }
 
-pub fn command(scale_help: String, default_theme: ThemeType) -> Command {
+pub fn command(scale_help: String, default_theme: Option<ThemeType>) -> Command {
     let file_arg = Arg::new("file")
         .required(true)
         .number_of_values(1)
         .value_name("FILE")
         .value_parser(value_parser!(PathBuf))
         .help("Path to the markdown file");
-    let theme_arg = Arg::new("theme")
+    let mut theme_arg = Arg::new("theme")
         .short('t')
         .long("theme")
         .number_of_values(1)
         .value_parser(value_parser!(ThemeType))
-        .default_value(default_theme.as_str())
         .help("Theme to use when rendering");
+    if let Some(theme) = default_theme {
+        theme_arg = theme_arg.default_value(theme.as_str());
+    }
 
     let scale_arg = Arg::new("scale")
         .short('s')

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -88,7 +88,7 @@ pub struct KeybindingsSection {
 #[derive(Deserialize, Debug, Default)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
-    pub theme: ThemeType,
+    pub theme: Option<ThemeType>,
     pub scale: Option<f32>,
     pub lines_to_scroll: LinesToScroll,
     pub light_theme: Option<OptionalTheme>,


### PR DESCRIPTION
Followup on the whole system-theme detection for testing

This makes it so that tests always explicitly pass what theme is being used instead of having the system theme detected. Detecting the system theme in tests is obviously problematic because it leads to different behavior depending on the system being tested on