### PR TITLE
Store raw image data as LZ4 compressed blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,6 +1620,7 @@ dependencies = [
  "image",
  "log",
  "lyon",
+ "lz4_flex",
  "memmap2",
  "notify",
  "open",
@@ -1921,6 +1922,15 @@ dependencies = [
  "float_next_after",
  "lyon_path",
  "thiserror",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b8c72594ac26bfd34f2d99dfced2edfaddfe8a476e3ff2ca0eb293d925c4f83"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ log = "0.4.17"
 env_logger = "0.10.0"
 notify = "5.1.0"
 dark-light = "1.0.0"
+# We only decompress our own compressed data, so disable `safe-decode` and
+# `checked-decode`
+lz4_flex = { version = "0.10.0", default-features = false, features = ["frame", "safe-encode", "std"] }
 
 # Uncomment for profiling
 # [profile.release]

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,13 +1,15 @@
 use crate::positioner::DEFAULT_MARGIN;
-use crate::utils::{Align, Point, Size};
+use crate::utils::{usize_in_mib, Align, Point, Size};
 use crate::InlyneEvent;
 use bytemuck::{Pod, Zeroable};
 use image::{ImageBuffer, RgbaImage};
+use lz4_flex::frame::{BlockSize, FrameDecoder, FrameEncoder, FrameInfo};
 use resvg::usvg_text_layout::TreeTextToPath;
 use std::fs::File;
-use std::io::Read;
+use std::io::{self, Cursor, Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use wgpu::util::DeviceExt;
 use wgpu::{Device, TextureFormat};
 use winit::event_loop::EventLoopProxy;
@@ -22,8 +24,34 @@ pub enum ImageSize {
 
 #[derive(Debug)]
 pub struct ImageData {
-    rgba_image: RgbaImage,
+    dimensions: (u32, u32),
+    lz4_blob: Vec<u8>,
     scale: bool,
+}
+
+impl ImageData {
+    fn new(image: RgbaImage, scale: bool) -> Self {
+        let dimensions = image.dimensions();
+
+        let mut frame_info = FrameInfo::new();
+        // This seems to speed up decompressing considerably
+        frame_info.block_size = BlockSize::Max256KB;
+        let mut lz4_enc = FrameEncoder::with_frame_info(frame_info, Vec::with_capacity(8_192));
+        lz4_enc.write_all(image.as_raw()).expect("I/O is in memory");
+        let mut lz4_blob = lz4_enc.finish().expect("We control compression");
+        lz4_blob.shrink_to_fit();
+
+        Self {
+            dimensions,
+            lz4_blob,
+            scale,
+        }
+    }
+
+    fn rgba_image_byte_size(&self) -> usize {
+        let (x, y) = self.dimensions;
+        x as usize * y as usize * 4
+    }
 }
 
 #[derive(Debug, Default)]
@@ -47,6 +75,19 @@ impl Image {
     ) {
         let dimensions = self.buffer_dimensions();
         if let Some(image_data) = self.image.lock().unwrap().as_ref() {
+            let start = Instant::now();
+            let mut lz4_dec = FrameDecoder::new(Cursor::new(&image_data.lz4_blob));
+            let mut rgba_image = Vec::with_capacity(image_data.rgba_image_byte_size());
+            io::copy(&mut lz4_dec, &mut rgba_image).expect("I/O is in memory");
+            let elapsed = start.elapsed();
+
+            log::debug!(
+                "Decompressing image: Compressed {:.2} MiB - Full {:.2} MiB - Time {:.2?}",
+                usize_in_mib(image_data.lz4_blob.len()),
+                usize_in_mib(rgba_image.len()),
+                elapsed,
+            );
+
             let texture_size = wgpu::Extent3d {
                 width: dimensions.0,
                 height: dimensions.1,
@@ -71,7 +112,7 @@ impl Image {
                     aspect: wgpu::TextureAspect::All,
                 },
                 // The actual pixel data
-                &image_data.rgba_image,
+                &rgba_image,
                 // The layout of the texture
                 wgpu::ImageDataLayout {
                     offset: 0,
@@ -132,10 +173,7 @@ impl Image {
             };
 
             if let Ok(image) = image::load_from_memory(&image_data) {
-                *(image_clone.lock().unwrap()) = Some(ImageData {
-                    rgba_image: image.into_rgba8(),
-                    scale: true,
-                });
+                *(image_clone.lock().unwrap()) = Some(ImageData::new(image.into_rgba8(), true));
             } else {
                 let opt = usvg::Options::default();
                 if let Ok(mut rtree) = usvg::Tree::from_data(&image_data, &opt) {
@@ -155,15 +193,15 @@ impl Image {
                         pixmap.as_mut(),
                     )
                     .unwrap();
-                    *(image_clone.lock().unwrap()) = Some(ImageData {
-                        rgba_image: ImageBuffer::from_raw(
+                    *(image_clone.lock().unwrap()) = Some(ImageData::new(
+                        ImageBuffer::from_raw(
                             pixmap.width(),
                             pixmap.height(),
                             pixmap.data().into(),
                         )
                         .unwrap(),
-                        scale: false,
-                    });
+                        false,
+                    ));
                 }
             }
             if let Ok(Some(callback)) = callback_clone.try_lock().as_deref() {
@@ -224,7 +262,7 @@ impl Image {
 
     pub fn buffer_dimensions(&self) -> (u32, u32) {
         if let Ok(Some(image)) = self.image.try_lock().as_deref() {
-            image.rgba_image.dimensions()
+            image.dimensions
         } else {
             (0, 0)
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,6 +8,10 @@ use winit::window::CursorIcon;
 
 use crate::image::ImageData;
 
+pub fn usize_in_mib(num: usize) -> f32 {
+    num as f32 / 1_024.0 / 1_024.0
+}
+
 pub type Line = ((f32, f32), (f32, f32));
 pub type Selection = ((f32, f32), (f32, f32));
 pub type Point = (f32, f32);


### PR DESCRIPTION
Resolves #45

(Well not quite, but it's a considerable improvement for now)

This PR changes the raw image data to be stored as LZ4 Frame Format blobs. LZ4 because it's got very fast compression/decompression speeds and the frame format because `lz4_flex`'s block format stores the output in a `Vec` allocated for the maximum possible output size which leads to a pretty large memory spike. Granted Linux (and Mac?) typically doesn't allocated zero'd pages until they're actually used for something else, but I figured the lower memory spike was worth the extra code complexity to handle streaming

## Demo

https://user-images.githubusercontent.com/30302768/229645749-dc4daaea-e092-4fba-84b2-ac4b9e84912d.mp4

## Profiles

### `main`

![image](https://user-images.githubusercontent.com/30302768/229646344-2da32284-da45-4541-86d1-94c62ce944bd.png)

### This PR

![image](https://user-images.githubusercontent.com/30302768/229646176-b92ad718-8497-4428-a65f-078b5a2ee153.png)

### Analysis

Above you can see that with this PR scrolling over all of `bun`'s README is typically a steady ~20 MiB of RAM with two spikes. One towards the beginning from loading the ~55 MiB RGBA8 data before compressing it into an LZ4 blob, and a second towards the end when that blob is decompressed to get rendered

The peak memory usage is a bit lower now since the raw image data generally going to be loaded and dropped at different times. This would cause a much larger difference on a file that has more uniform sizes whereas `bun`'s README has a single outlier