### PR TITLE
Make everything async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-once-cell"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b49bd4c5b769125ea6323601c39815848972880efd33ffb2d01f9f909adc699"
+
+[[package]]
 name = "async-recursion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,24 +1171,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -1200,25 +1206,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.27"
+name = "futures-macro"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.8",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1617,6 +1635,7 @@ name = "inlyne"
 version = "0.2.1"
 dependencies = [
  "anyhow",
+ "async-once-cell",
  "bytemuck",
  "clap",
  "clap_complete",
@@ -1634,12 +1653,12 @@ dependencies = [
  "memmap2",
  "notify",
  "open",
- "pollster",
  "pretty_assertions",
  "reqwest",
  "resvg",
  "serde",
  "tiny-skia",
+ "tokio",
  "toml",
  "usvg",
  "wgpu",
@@ -2722,12 +2741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pollster"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,10 +2958,12 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -3263,6 +3278,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3643,9 +3667,23 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4029,6 +4067,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wayland-client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/trimental/inlyne"
 homepage = "https://github.com/trimental/inlyne"
 
 [dependencies]
-pollster = "0.3.0"
 wgpu_glyph =  { git = "https://github.com/sconybeare/wgpu_glyph", branch = "wgpu-0.15" }
 winit = "0.28.3"
 wgpu = "0.15.1"
@@ -29,7 +28,7 @@ anyhow = "1.0.70"
 dirs = "5.0.0"
 serde = { version = "1.0.158", features = ["derive"] }
 toml = "0.7.3"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", features = ["blocking", "json", "stream"] }
 font-kit = "0.11.0"
 memmap2 = "0.5.10"
 log = "0.4.17"
@@ -40,6 +39,8 @@ dark-light = "1.0.0"
 # We only decompress our own compressed data, so disable `safe-decode` and
 # `checked-decode`
 lz4_flex = { version = "0.10.0", default-features = false, features = ["frame", "safe-encode", "std"] }
+tokio = { version = "1", features = ["full"] }
+async-once-cell = { version = "0.4.4", features = ["unpin"] }
 
 # Uncomment for profiling
 # [profile.release]

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,32 +1,30 @@
 use crate::positioner::DEFAULT_MARGIN;
 use crate::utils::{usize_in_mib, Align, Point, Size};
-use crate::InlyneEvent;
+use async_once_cell::unpin::Lazy;
 use bytemuck::{Pod, Zeroable};
 use image::{ImageBuffer, RgbaImage};
 use lz4_flex::frame::{BlockSize, FrameDecoder, FrameEncoder, FrameInfo};
 use resvg::usvg_text_layout::TreeTextToPath;
-use std::fs::File;
-use std::io::{self, Cursor, Read, Write};
+use std::io::{self, Cursor, Write};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 use wgpu::util::DeviceExt;
 use wgpu::{Device, TextureFormat};
-use winit::event_loop::EventLoopProxy;
 
 use std::borrow::Cow;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ImageSize {
     PxWidth(u32),
     PxHeight(u32),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default, Clone)]
 pub struct ImageData {
-    dimensions: (u32, u32),
     lz4_blob: Vec<u8>,
     scale: bool,
+    dimensions: (u32, u32),
 }
 
 impl ImageData {
@@ -61,30 +59,41 @@ impl ImageData {
     }
 }
 
-#[derive(Debug, Default)]
 pub struct Image {
-    pub image: Arc<Mutex<Option<ImageData>>>,
+    pub image: Arc<Lazy<anyhow::Result<ImageData>>>,
     pub is_aligned: Option<Align>,
-    callback: Arc<Mutex<Option<EventLoopProxy<InlyneEvent>>>>,
     pub size: Option<ImageSize>,
     pub bind_group: Option<Arc<wgpu::BindGroup>>,
     pub is_link: Option<String>,
     pub hidpi_scale: f32,
 }
 
+impl Default for Image {
+    fn default() -> Self {
+        Self {
+            image: Arc::new(Lazy::new(Box::pin(async { Ok(ImageData::default()) }))),
+            is_aligned: Default::default(),
+            size: Default::default(),
+            bind_group: Default::default(),
+            is_link: Default::default(),
+            hidpi_scale: Default::default(),
+        }
+    }
+}
+
 impl Image {
-    pub fn create_bind_group(
+    pub async fn create_bind_group(
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         sampler: &wgpu::Sampler,
         bindgroup_layout: &wgpu::BindGroupLayout,
     ) {
-        let dimensions = self.buffer_dimensions();
-        if let Some(image_data) = self.image.lock().unwrap().as_ref() {
+        let dimensions = self.buffer_dimensions().unwrap();
+        if let Ok(image) = self.image.get().await {
             let start = Instant::now();
-            let mut lz4_dec = FrameDecoder::new(Cursor::new(&image_data.lz4_blob));
-            let mut rgba_image = Vec::with_capacity(image_data.rgba_image_byte_size());
+            let mut lz4_dec = FrameDecoder::new(Cursor::new(&image.lz4_blob));
+            let mut rgba_image = Vec::with_capacity(image.rgba_image_byte_size());
             io::copy(&mut lz4_dec, &mut rgba_image).expect("I/O is in memory");
 
             log::debug!("Decompressing image: Time {:.2?}", start.elapsed());
@@ -142,85 +151,61 @@ impl Image {
         }
     }
 
-    pub fn from_src(src: String, file_path: PathBuf, hidpi_scale: f32) -> Image {
-        let image = Arc::new(Mutex::new(None));
-        let callback = Arc::new(Mutex::new(None::<EventLoopProxy<InlyneEvent>>));
-        let image_clone = image.clone();
-        let callback_clone = callback.clone();
-        std::thread::spawn(move || {
-            let mut src_path = PathBuf::from(src.clone());
+    pub fn from_src(src: String, file_path: PathBuf, hidpi_scale: f32) -> anyhow::Result<Image> {
+        let image = async move {
+            let mut src_path = PathBuf::from(&src);
             if src_path.is_relative() {
                 if let Some(parent_dir) = file_path.parent() {
                     src_path = parent_dir.join(src_path.strip_prefix("./").unwrap_or(&src_path));
                 }
             }
 
-            let image_data = if let Ok(mut img_file) = File::open(&src_path) {
-                let img_file_size = src_path.metadata().unwrap().len();
-                let mut img_buf = Vec::with_capacity(img_file_size as usize);
-                img_file.read_to_end(&mut img_buf).unwrap();
-                img_buf
-            } else if let Ok(bytes) = reqwest::blocking::get(&src).and_then(|resp| resp.bytes()) {
-                // Limit the length to 20 MiB to avoid malicious servers causing OOM
-                const MAX_SIZE: usize = 20 * 1_024 * 1_024;
-
-                if bytes.len() > MAX_SIZE {
-                    return;
-                }
-
-                bytes.to_vec()
+            let image_data = if let Ok(img_file) = tokio::fs::read(&src_path).await {
+                img_file
             } else {
-                return;
+                reqwest::get(&src).await?.bytes().await?.to_vec()
             };
 
             if let Ok(image) = image::load_from_memory(&image_data) {
-                *(image_clone.lock().unwrap()) = Some(ImageData::new(image.into_rgba8(), true));
+                Ok(ImageData::new(image.into_rgba8(), true))
             } else {
                 let opt = usvg::Options::default();
-                if let Ok(mut rtree) = usvg::Tree::from_data(&image_data, &opt) {
-                    let mut fontdb = resvg::usvg_text_layout::fontdb::Database::new();
-                    fontdb.load_system_fonts();
-                    rtree.convert_text(&fontdb);
-                    let pixmap_size = rtree.size.to_screen_size();
-                    let mut pixmap = tiny_skia::Pixmap::new(
-                        (pixmap_size.width() as f32 * hidpi_scale) as u32,
-                        (pixmap_size.height() as f32 * hidpi_scale) as u32,
-                    )
-                    .unwrap();
-                    resvg::render(
-                        &rtree,
-                        usvg::FitTo::Zoom(hidpi_scale),
-                        tiny_skia::Transform::default(),
-                        pixmap.as_mut(),
-                    )
-                    .unwrap();
-                    *(image_clone.lock().unwrap()) = Some(ImageData::new(
-                        ImageBuffer::from_raw(
-                            pixmap.width(),
-                            pixmap.height(),
-                            pixmap.data().into(),
-                        )
+                let mut rtree = usvg::Tree::from_data(&image_data, &opt)?;
+                let mut fontdb = resvg::usvg_text_layout::fontdb::Database::new();
+                fontdb.load_system_fonts();
+                rtree.convert_text(&fontdb);
+                let pixmap_size = rtree.size.to_screen_size();
+                let mut pixmap = tiny_skia::Pixmap::new(
+                    (pixmap_size.width() as f32 * hidpi_scale) as u32,
+                    (pixmap_size.height() as f32 * hidpi_scale) as u32,
+                )
+                .unwrap();
+                resvg::render(
+                    &rtree,
+                    usvg::FitTo::Zoom(hidpi_scale),
+                    tiny_skia::Transform::default(),
+                    pixmap.as_mut(),
+                )
+                .unwrap();
+                Ok(ImageData::new(
+                    ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.data().into())
                         .unwrap(),
-                        false,
-                    ));
-                }
+                    false,
+                ))
             }
-            if let Ok(Some(callback)) = callback_clone.try_lock().as_deref() {
-                callback
-                    .send_event(InlyneEvent::LoadedImage(src, image_clone.clone()))
-                    .unwrap();
-            }
-        });
+        };
 
-        Image {
-            image,
-            callback,
+        Ok(Image {
+            image: Arc::new(Lazy::new(Box::pin(image))),
             hidpi_scale,
             ..Default::default()
-        }
+        })
     }
 
-    pub fn from_image_data(image_data: Arc<Mutex<Option<ImageData>>>, hidpi_scale: f32) -> Image {
+    pub fn from_image_data(
+        image_data: Arc<Lazy<anyhow::Result<ImageData>>>,
+        hidpi_scale: f32,
+    ) -> Image {
         Image {
             image: image_data,
             hidpi_scale,
@@ -230,10 +215,6 @@ impl Image {
 
     pub fn set_link(&mut self, link: String) {
         self.is_link = Some(link);
-    }
-
-    pub fn add_callback(&mut self, eventloop_proxy: EventLoopProxy<InlyneEvent>) {
-        *(self.callback.lock().unwrap()) = Some(eventloop_proxy);
     }
 
     pub fn with_align(mut self, align: Align) -> Self {
@@ -246,43 +227,37 @@ impl Image {
         self
     }
 
-    pub fn dimensions_from_image_size(&self, size: &ImageSize) -> (u32, u32) {
-        let image_dimensions = self.buffer_dimensions();
+    pub fn dimensions_from_image_size(&self, size: &ImageSize) -> Option<(u32, u32)> {
+        let image_dimensions = self.buffer_dimensions()?;
         match size {
-            ImageSize::PxWidth(px_width) => (
+            ImageSize::PxWidth(px_width) => Some((
                 *px_width,
                 ((*px_width as f32 / image_dimensions.0 as f32) * image_dimensions.1 as f32) as u32,
-            ),
-            ImageSize::PxHeight(px_height) => (
+            )),
+            ImageSize::PxHeight(px_height) => Some((
                 ((*px_height as f32 / image_dimensions.1 as f32) * image_dimensions.0 as f32)
                     as u32,
                 *px_height,
-            ),
+            )),
         }
     }
 
-    pub fn buffer_dimensions(&self) -> (u32, u32) {
-        if let Ok(Some(image)) = self.image.try_lock().as_deref() {
-            image.dimensions
-        } else {
-            (0, 0)
-        }
+    fn buffer_dimensions(&self) -> Option<(u32, u32)> {
+        Some(self.image.try_get()?.as_ref().ok()?.dimensions)
     }
-    pub fn dimensions(&self, screen_size: Size, zoom: f32) -> (u32, u32) {
-        let buffer_size = self.buffer_dimensions();
+
+    fn dimensions(&self, screen_size: Size, zoom: f32) -> Option<(u32, u32)> {
+        let buffer_size = self.buffer_dimensions()?;
         let mut buffer_size = (buffer_size.0 as f32 * zoom, buffer_size.1 as f32 * zoom);
-        if let Ok(Some(image)) = self.image.try_lock().as_deref() {
+        if let Some(Ok(image)) = self.image.try_get() {
             if image.scale {
                 buffer_size.0 *= self.hidpi_scale;
                 buffer_size.1 *= self.hidpi_scale;
             }
         }
         let max_width = screen_size.0 - 2. * DEFAULT_MARGIN;
-        if let Some(dimensions) = self
-            .size
-            .as_ref()
-            .map(|image_size| self.dimensions_from_image_size(image_size))
-        {
+        let dimensions = if let Some(size) = self.size.clone() {
+            let dimensions = self.dimensions_from_image_size(&size)?;
             let target_dimensions = (
                 (dimensions.0 as f32 * self.hidpi_scale * zoom) as u32,
                 (dimensions.1 as f32 * self.hidpi_scale * zoom) as u32,
@@ -302,12 +277,13 @@ impl Image {
             )
         } else {
             (buffer_size.0 as u32, buffer_size.1 as u32)
-        }
+        };
+        Some(dimensions)
     }
 
-    pub fn size(&self, screen_size: Size, zoom: f32) -> Size {
-        let dimensions = self.dimensions(screen_size, zoom);
-        (dimensions.0 as f32, dimensions.1 as f32)
+    pub fn size(&mut self, screen_size: Size, zoom: f32) -> Option<Size> {
+        self.dimensions(screen_size, zoom)
+            .map(|d| (d.0 as f32, d.1 as f32))
     }
 }
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -357,16 +357,12 @@ impl TokenSink for HtmlInterpreter {
                                             src.clone(),
                                             self.file_path.clone(),
                                             self.hidpi_scale,
+                                            self.event_proxy.clone(),
                                         )
                                         .unwrap()
                                         .with_align(*align),
                                     };
-                                    let image_ref = image.image.clone();
-                                    let event_proxy = self.event_proxy.clone();
-                                    tokio::spawn(async move {
-                                        image_ref.get().await;
-                                        event_proxy.send_event(InlyneEvent::Reposition).unwrap();
-                                    });
+
                                     if let Some(link) = self.state.text_options.link.last() {
                                         image.set_link((*link).clone())
                                     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -8,6 +8,7 @@ use crate::positioner::Spacer;
 use crate::positioner::DEFAULT_MARGIN;
 use crate::table::Table;
 use crate::ImageCache;
+use crate::InlyneEvent;
 
 use crate::color::Theme;
 use crate::text::{Text, TextBox};
@@ -23,6 +24,7 @@ use html5ever::tokenizer::TagToken;
 use html5ever::tokenizer::{Token, TokenSink, TokenSinkResult};
 use html5ever::tokenizer::{Tokenizer, TokenizerOpts};
 use html5ever::Attribute;
+use winit::event_loop::EventLoopProxy;
 use winit::window::Window;
 use Token::{CharacterTokens, EOFToken};
 
@@ -126,6 +128,7 @@ pub struct HtmlInterpreter {
     stopped: bool,
     first_pass: bool,
     image_cache: ImageCache,
+    event_proxy: EventLoopProxy<InlyneEvent>,
 }
 
 impl HtmlInterpreter {
@@ -136,6 +139,7 @@ impl HtmlInterpreter {
         hidpi_scale: f32,
         file_path: PathBuf,
         image_cache: ImageCache,
+        event_proxy: EventLoopProxy<InlyneEvent>,
     ) -> Self {
         Self {
             window,
@@ -152,6 +156,7 @@ impl HtmlInterpreter {
             stopped: false,
             first_pass: true,
             image_cache,
+            event_proxy,
         }
     }
 
@@ -349,12 +354,19 @@ impl TokenSink for HtmlInterpreter {
                                         )
                                         .with_align(*align),
                                         _ => Image::from_src(
-                                            src,
+                                            src.clone(),
                                             self.file_path.clone(),
                                             self.hidpi_scale,
                                         )
+                                        .unwrap()
                                         .with_align(*align),
                                     };
+                                    let image_ref = image.image.clone();
+                                    let event_proxy = self.event_proxy.clone();
+                                    tokio::spawn(async move {
+                                        image_ref.get().await;
+                                        event_proxy.send_event(InlyneEvent::Reposition).unwrap();
+                                    });
                                     if let Some(link) = self.state.text_options.link.last() {
                                         image.set_link((*link).clone())
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,8 @@ use crate::opts::Opts;
 use crate::table::Table;
 use crate::text::Text;
 
+use crate::image::ImageData;
+use async_once_cell::unpin::Lazy;
 use keybindings::{Action, Key, KeyCombos, ModifiedKey};
 use opts::Args;
 use opts::Config;
@@ -27,7 +29,8 @@ use positioner::DEFAULT_MARGIN;
 use positioner::DEFAULT_PADDING;
 use renderer::Renderer;
 use text::TextBox;
-use utils::{ImageCache, MaybeImageData, Point, Rect, Size};
+use tokio::task;
+use utils::{ImageCache, Point, Rect, Size};
 
 use anyhow::Context;
 use copypasta::{ClipboardContext, ClipboardProvider};
@@ -44,6 +47,7 @@ use winit::{
 
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
@@ -54,11 +58,16 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-#[derive(Debug)]
 pub enum InlyneEvent {
-    LoadedImage(String, MaybeImageData),
+    LoadedImage(String, Arc<Lazy<anyhow::Result<ImageData>>>),
     FileReload,
     Reposition,
+}
+
+impl Debug for InlyneEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Inlyne Event")
+    }
 }
 
 pub enum Hoverable<'a> {
@@ -67,7 +76,6 @@ pub enum Hoverable<'a> {
     Summary(&'a Section),
 }
 
-#[derive(Debug)]
 pub enum Element {
     TextBox(TextBox),
     Spacer(Spacer),
@@ -223,12 +231,14 @@ impl Inlyne {
             renderer.hidpi_scale,
             args.file_path.clone(),
             image_cache.clone(),
+            event_loop.create_proxy(),
         );
 
         let (interpreter_sender, interpreter_reciever) = channel();
         let interpreter_should_queue = interpreter.should_queue.clone();
-        std::thread::spawn(move || interpreter.intepret_md(interpreter_reciever));
-        let md_string = std::fs::read_to_string(&opts.file_path)
+        task::spawn_blocking(|| interpreter.intepret_md(interpreter_reciever));
+        let md_string = tokio::fs::read_to_string(&opts.file_path)
+            .await
             .with_context(|| format!("Could not read file at {:?}", opts.file_path))?;
         interpreter_sender.send(md_string)?;
 
@@ -248,7 +258,7 @@ impl Inlyne {
         })
     }
 
-    pub fn run(mut self) {
+    pub async fn run(mut self) {
         let mut pending_resize = None;
         let mut scrollbar_held = None;
         let mut mouse_down = false;
@@ -295,21 +305,7 @@ impl Inlyne {
                             .map(|mut queue| queue.drain(..).collect::<Vec<Element>>())
                     };
                     if let Ok(queue) = queue {
-                        for mut element in queue {
-                            // Adds callback for when image is loaded to reposition and redraw
-                            match element {
-                                Element::Image(ref mut image) => {
-                                    image.add_callback(event_loop_proxy.clone());
-                                }
-                                Element::Row(ref mut row) => {
-                                    for element in &mut row.elements {
-                                        if let Element::Image(ref mut image) = element.inner {
-                                            image.add_callback(event_loop_proxy.clone());
-                                        }
-                                    }
-                                }
-                                _ => {}
-                            }
+                        for element in queue {
                             // Position element and add it to elements
                             let mut positioned_element = Positioned::new(element);
                             self.renderer
@@ -700,14 +696,15 @@ impl Inlyne {
     }
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     env_logger::Builder::new()
         .filter_level(log::LevelFilter::Error)
         .filter_module("inlyne", log::LevelFilter::Info)
         .parse_env("INLYNE_LOG")
         .init();
 
-    let config = match Config::load() {
+    let config = match Config::load().await {
         Ok(config) => config,
         Err(err) => {
             log::warn!(
@@ -719,10 +716,10 @@ fn main() -> anyhow::Result<()> {
     };
     let args = Args::new(&config);
     let opts = Opts::parse_and_load_from(&args, config);
-    let inlyne = pollster::block_on(Inlyne::new(&opts, args))?;
+    let inlyne = Inlyne::new(&opts, args).await?;
 
     inlyne.spawn_watcher();
-    inlyne.run();
+    inlyne.run().await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,7 @@ impl Inlyne {
         })
     }
 
-    pub async fn run(mut self) {
+    pub fn run(mut self) {
         let mut pending_resize = None;
         let mut scrollbar_held = None;
         let mut mouse_down = false;
@@ -719,7 +719,7 @@ async fn main() -> anyhow::Result<()> {
     let inlyne = Inlyne::new(&opts, args).await?;
 
     inlyne.spawn_watcher();
-    inlyne.run().await;
+    inlyne.run();
 
     Ok(())
 }

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -73,7 +73,6 @@ pub fn command(scale_help: String, default_theme: Option<ThemeType>) -> Command 
         .value_parser(value_parser!(f32))
         .help("Maximum width of page in pixels");
 
-
     command!()
         .arg(file_arg)
         .arg(theme_arg)

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -1,5 +1,3 @@
-use std::fs;
-
 use super::ThemeType;
 use crate::{color, keybindings::Keybindings};
 
@@ -99,11 +97,13 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn load() -> anyhow::Result<Self> {
+    pub async fn load() -> anyhow::Result<Self> {
         let config_dir = dirs::config_dir().context("Failed detecting config dir")?;
         let config_path = config_dir.join("inlyne").join("inlyne.toml");
         if config_path.is_file() {
-            let text = fs::read_to_string(&config_path).context("Failed reading config file")?;
+            let text = tokio::fs::read_to_string(&config_path)
+                .await
+                .context("Failed reading config file")?;
             let config = toml::from_str(&text)?;
             Ok(config)
         } else {

--- a/src/positioner.rs
+++ b/src/positioner.rs
@@ -93,11 +93,12 @@ impl Positioner {
                 (0., spacer.space * self.hidpi_scale * zoom),
             ),
             Element::Image(image) => {
-                let size = image.size(
-                    (self.screen_size.0.min(self.page_width), self.screen_size.1),
-                    zoom,
-                );
-
+                let size = image
+                    .size(
+                        (self.screen_size.0.min(self.page_width), self.screen_size.1),
+                        zoom,
+                    )
+                    .unwrap_or_default();
                 match image.is_aligned {
                     Some(Align::Center) => Rect::new(
                         (self.screen_size.0 / 2. - size.0 / 2., self.reserved_height),
@@ -257,7 +258,6 @@ impl Spacer {
     }
 }
 
-#[derive(Debug)]
 pub struct Row {
     pub elements: Vec<Positioned<Element>>,
     pub hidpi_scale: f32,
@@ -272,7 +272,6 @@ impl Row {
     }
 }
 
-#[derive(Debug)]
 pub struct Section {
     pub elements: Vec<Positioned<Element>>,
     pub hidpi_scale: f32,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use async_once_cell::unpin::Lazy;
 use wgpu_glyph::ab_glyph;
 use winit::window::CursorIcon;
 
@@ -16,8 +17,7 @@ pub type Line = ((f32, f32), (f32, f32));
 pub type Selection = ((f32, f32), (f32, f32));
 pub type Point = (f32, f32);
 pub type Size = (f32, f32);
-pub type MaybeImageData = Arc<Mutex<Option<ImageData>>>;
-pub type ImageCache = Arc<Mutex<HashMap<String, MaybeImageData>>>;
+pub type ImageCache = Arc<Mutex<HashMap<String, Arc<Lazy<anyhow::Result<ImageData>>>>>>;
 
 #[derive(Debug, Clone)]
 pub struct Rect {


### PR DESCRIPTION
Use Tokio to make everything async instead of using threads. This mainly impacts image loading which used to use thread spacing before. I feel as though this is a bit cleaner at the cost of feeling a bit 'magic-like'. I'm interested to hear your thoughts about this @CosmicHorrorDev. 

I haven't done any benchmarking against the old implementation yet. This should help with streaming images directly into a compressed format.