### PR TITLE
Add a `deny.toml` file for `cargo-deny`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[licenses]
+allow = [
+    "MIT",
+
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Zlib",
+]
+
+exceptions = [
+    # We will no longer depend on this dependency after `copypasta` updates
+    # `clipboard-win`. Keeping it separate as a reminder to drop eventually
+    { allow = ["BSL-1.0"], name = "lazy-bytes-cast" }
+
+    # Not a recommended library for source code. Try to limit dependecies that
+    # use this
+    { allow = ["CC0-1.0"], name = "hexf-parse" },
+    { allow = ["CC0-1.0"], name = "notify" },
+
+    # This crate gets used by most of the ecosystem. If we're in trouble then,
+    # so is everyone else ¯\_(ツ)_/¯
+    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+]

--- a/deny.toml
+++ b/deny.toml
@@ -13,7 +13,7 @@ allow = [
 exceptions = [
     # We will no longer depend on this dependency after `copypasta` updates
     # `clipboard-win`. Keeping it separate as a reminder to drop eventually
-    { allow = ["BSL-1.0"], name = "lazy-bytes-cast" }
+    { allow = ["BSL-1.0"], name = "lazy-bytes-cast" },
 
     # Not a recommended library for source code. Try to limit dependecies that
     # use this


### PR DESCRIPTION
This just adds portions for dealing with the licenses of all of our dependencies. `cargo-deny` also supports a lot more functionality on dealing with security advisories or detecting duplicate dependencies that could be useful as well, but wasn't the focus of this PR