### PR TITLE
Temporarily skip generating completions for aarch64-apple-darwin release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,14 @@ jobs:
           inlyne_bin="$staging/inlyne"
         fi
 
-        "$inlyne_bin" --gen-completions bash       > "$comp_out/inlyne.bash"
-        "$inlyne_bin" --gen-completions elvish     > "$comp_out/inlyne.elv"
-        "$inlyne_bin" --gen-completions fish       > "$comp_out/inlyne.fish"
-        "$inlyne_bin" --gen-completions powershell > "$comp_out/inlyne.ps1"
-        "$inlyne_bin" --gen-completions zsh        > "$comp_out/_inlyne"
+        # Skip `aarch64-apple-darwin` for now since it's failing in CI
+        if [ "${{ matrix.target }}" != "aarch64-apple-darwin" ]; then
+          "$inlyne_bin" --gen-completions bash       > "$comp_out/inlyne.bash"
+          "$inlyne_bin" --gen-completions elvish     > "$comp_out/inlyne.elv"
+          "$inlyne_bin" --gen-completions fish       > "$comp_out/inlyne.fish"
+          "$inlyne_bin" --gen-completions powershell > "$comp_out/inlyne.ps1"
+          "$inlyne_bin" --gen-completions zsh        > "$comp_out/_inlyne"
+        fi
 
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           7z a "$staging.zip" "$staging"


### PR DESCRIPTION
For some reason this is failing in CI with a bad cpu type

In the future we generate these static assets before-hand or have them generated from a build script instead of generating them at run-time in the release pipeline

Would be good to repush the release tag after this is merged