### PR TITLE
Support bare relative links

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -479,11 +479,14 @@ impl Inlyne {
                                             // Simply canonicalizing it doesn't suffice and leads to "no such file or directory"
                                             let current_parent =
                                                 args.file_path.parent().expect("no current parent");
-                                            let link_without_prefix: &Path = path
+                                            let mut normalized_link = path.as_path();
+                                            if let Ok(stripped) = normalized_link
                                                 .strip_prefix(std::path::Component::CurDir)
-                                                .expect("no CurDir prefix");
+                                            {
+                                                normalized_link = stripped;
+                                            }
                                             let mut link = current_parent.to_path_buf();
-                                            link.push(link_without_prefix);
+                                            link.push(normalized_link);
                                             link
                                         } else {
                                             path


### PR DESCRIPTION
Fixes #95 

Markdown (or at least GitHub's markdown w/ extensions) supports bare relative links like

```markdown
[link](some_file.md)
```

But this would fail when trying to strip the current directory prefix because there isn't one

Manually tested that this still works with anchors, paths prefixed with `./`, etc. This whole section could use a refactor and some automated testing