### PR TITLE
Add repology badge for package manager installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,9 @@ view markdown files in the blink of an eye.
 ## Install
 
 To install just use `cargo install inlyne`, everything comes pre-bundled.
+Alternatively you can install through various package managers.
 
-On NetBSD, a pre-compiled binary, including an example configuration file, is available from the official repositories. To install it, simply run:
-
-```bash
-pkgin install inlyne
-```
+[![Packaging status](https://repology.org/badge/vertical-allrepos/inlyne.svg)](https://repology.org/project/inlyne/versions)
 
 ## Features
 


### PR DESCRIPTION
Swaps out the package manager specific installation instructions for a repology badge that links to a page with various installation information. The listing is decently comprehensive and will stay up to date

The current listing as viewed through `inlyne`

![image](https://github.com/trimental/inlyne/assets/30302768/ba10ff0c-446d-423d-a38c-cc57ca06c409)
