### PR TITLE
Basic YAML front-matter support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "const-cstr"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +938,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1536,6 +1554,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,6 +1696,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1685,8 +1713,11 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger",
  "font-kit",
+ "html-escape",
  "html5ever",
  "image",
+ "indexmap",
+ "insta",
  "log",
  "lyon",
  "lz4_flex",
@@ -1698,6 +1729,7 @@ dependencies = [
  "reqwest",
  "resvg",
  "serde",
+ "serde_yaml",
  "tiny-skia 0.9.0",
  "toml",
  "usvg",
@@ -1724,6 +1756,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "insta"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -3286,6 +3331,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3301,6 +3359,12 @@ name = "simd-adler32"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "simplecss"
@@ -3917,6 +3981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3992,6 +4062,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ dark-light = "1.0.0"
 # `checked-decode`
 lz4_flex = { version = "0.10.0", default-features = false, features = ["frame", "safe-encode", "std"] }
 pollster = "0.3.0"
+serde_yaml = "0.9.21"
+indexmap = { version = "1.9.3", features = ["serde"] }
+html-escape = "0.2.13"
 
 # Uncomment for profiling
 # [profile.release]
@@ -51,4 +54,5 @@ strip = true
 lto = true
 
 [dev-dependencies]
+insta = "1.29.0"
 pretty_assertions = "1.3.0"

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -12,10 +12,9 @@ use crate::InlyneEvent;
 
 use crate::color::Theme;
 use crate::text::{Text, TextBox};
-use crate::utils::Align;
+use crate::utils::{markdown_to_html, Align};
 use crate::Element;
 
-use comrak::{markdown_to_html_with_plugins, ComrakOptions};
 use html5ever::local_name;
 use html5ever::tendril::*;
 use html5ever::tokenizer::BufferQueue;
@@ -166,19 +165,9 @@ impl HtmlInterpreter {
 
     pub fn interpret_md(self, receiver: mpsc::Receiver<String>) {
         let mut input = BufferQueue::new();
-        let mut options = ComrakOptions::default();
-        options.extension.table = true;
-        options.extension.strikethrough = true;
-        options.extension.tasklist = true;
-        options.parse.smart = true;
-        options.render.unsafe_ = true;
 
-        let mut plugins = comrak::ComrakPlugins::default();
-        let adapter = comrak::plugins::syntect::SyntectAdapter::new(
-            self.theme.code_highlighter.as_syntect_name(),
-        );
-        plugins.render.codefence_syntax_highlighter = Some(&adapter);
         let span_color = native_color(self.theme.code_color, &self.surface_format);
+        let code_highlighter = self.theme.code_highlighter;
         let mut tok = Tokenizer::new(self, TokenizerOpts::default());
 
         for md_string in receiver {
@@ -193,7 +182,10 @@ impl HtmlInterpreter {
                 };
                 tok.sink.current_textbox = TextBox::new(Vec::new(), tok.sink.hidpi_scale);
                 tok.sink.stopped = false;
-                let htmlified = markdown_to_html_with_plugins(&md_string, &options, &plugins);
+                let htmlified = markdown_to_html(&md_string, code_highlighter);
+                // let htmlified = markdown_to_html_with_plugins(&md_string, &options, &plugins);
+
+                println!("{htmlified}");
 
                 input.push_back(
                     Tendril::from_str(&htmlified)

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -183,9 +183,6 @@ impl HtmlInterpreter {
                 tok.sink.current_textbox = TextBox::new(Vec::new(), tok.sink.hidpi_scale);
                 tok.sink.stopped = false;
                 let htmlified = markdown_to_html(&md_string, code_highlighter);
-                // let htmlified = markdown_to_html_with_plugins(&md_string, &options, &plugins);
-
-                println!("{htmlified}");
 
                 input.push_back(
                     Tendril::from_str(&htmlified)


### PR DESCRIPTION
Resolves #93

This adds in basic YAML front-matter support (basic in the sense that I couldn't find any documentation on what GitHub's front-matter supports, so I just worked off the provided example)

The example provided in #93 created a nested table, but `inlyne` doesn't handle rendering that correctly yet (#110), so instead `{Skipped nested table}` placeholder text is inserted and a warning log is emitted

## Demo

```md
---
title: Title
date: 2018-05-01
tags:
  - another tag
---
# Markdown header

body
```

**Rendered by `inlyne`**

![image](https://github.com/trimental/inlyne/assets/30302768/73d906e9-7a2e-4ec4-99a2-63d9d85f3e86)
