### PR TITLE
Add ability to scroll with PageUp/PageDown

### DIFF
--- a/src/keybindings/defaults.rs
+++ b/src/keybindings/defaults.rs
@@ -52,6 +52,10 @@ pub fn defaults() -> Vec<(Action, KeyCombo)> {
         (Action::ScrollUp, KeyCombo::from(VirtKey::Up)),
         // Scroll down: Down-arrow
         (Action::ScrollDown, KeyCombo::from(VirtKey::Down)),
+        // Page up: PageUp
+        (Action::PageUp, KeyCombo::from(VirtKey::PageUp)),
+        // Page down: PageDown
+        (Action::PageDown, KeyCombo::from(VirtKey::PageDown)),
         // Go to top of doc: Home
         (Action::ToTop, KeyCombo::from(VirtKey::Home)),
         // Go to bottom of doc: End

--- a/src/keybindings/mod.rs
+++ b/src/keybindings/mod.rs
@@ -167,6 +167,8 @@ pub enum Action {
     ToBottom,
     ScrollUp,
     ScrollDown,
+    PageUp,
+    PageDown,
     ZoomIn,
     ZoomOut,
     ZoomReset,

--- a/src/main.rs
+++ b/src/main.rs
@@ -575,6 +575,23 @@ impl Inlyne {
                                         lines,
                                     )
                                 }
+                                a_page @ (Action::PageUp | Action::PageDown) => {
+                                    // Move 90% of current page height
+                                    let scroll_amount = self.renderer.config.height as f32 * 0.9;
+                                    let scroll_with_direction = match a_page {
+                                        Action::PageUp => scroll_amount,
+                                        Action::PageDown => -scroll_amount,
+                                        _ => unreachable!(
+                                            "This arm is only for page up/down actions"
+                                        ),
+                                    };
+
+                                    Self::scroll_pixels(
+                                        &mut self.renderer,
+                                        &self.window,
+                                        scroll_with_direction,
+                                    );
+                                }
                                 a_zoom @ (Action::ZoomIn | Action::ZoomOut | Action::ZoomReset) => {
                                     let zoom = match a_zoom {
                                         Action::ZoomIn => self.renderer.zoom * 1.1,


### PR DESCRIPTION
I opted for scrolling 90% of the current page height since scrolling a full page seemed like it would be a bit jarring. Scrolling slightly less than a full page seems to be a common way of handling things from looking at how other programs manage it