### PR TITLE
Make invalid states unreachable

### DIFF
--- a/src/keybindings/action.rs
+++ b/src/keybindings/action.rs
@@ -1,0 +1,16 @@
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Action {
+    ToTop,
+    ToBottom,
+    ScrollUp,
+    ScrollDown,
+    PageUp,
+    PageDown,
+    ZoomIn,
+    ZoomOut,
+    ZoomReset,
+    Copy,
+    Quit,
+}

--- a/src/keybindings/action.rs
+++ b/src/keybindings/action.rs
@@ -1,16 +1,22 @@
-use serde::Deserialize;
-
-#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Action {
-    ToTop,
-    ToBottom,
-    ScrollUp,
-    ScrollDown,
-    PageUp,
-    PageDown,
-    ZoomIn,
-    ZoomOut,
-    ZoomReset,
+    ToEdge(VertDirection),
+    Scroll(VertDirection),
+    Page(VertDirection),
+    Zoom(Zoom),
     Copy,
     Quit,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VertDirection {
+    Up,
+    Down,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Zoom {
+    In,
+    Out,
+    Reset,
 }

--- a/src/keybindings/defaults.rs
+++ b/src/keybindings/defaults.rs
@@ -1,4 +1,7 @@
-use super::{Action, Key, KeyCombo, ModifiedKey};
+use super::{
+    action::{Action, VertDirection, Zoom},
+    Key, KeyCombo, ModifiedKey,
+};
 
 use winit::event::{ModifiersState, VirtualKeyCode as VirtKey};
 
@@ -19,14 +22,14 @@ pub fn defaults() -> Vec<(Action, KeyCombo)> {
         ),
         // Zoom in: Ctrl++ / Command++
         (
-            Action::ZoomIn,
+            Action::Zoom(Zoom::In),
             KeyCombo(vec![ModifiedKey(
                 Key::from(VirtKey::Equals),
                 ctrl_or_command | ModifiersState::SHIFT,
             )]),
         ),
         (
-            Action::ZoomIn,
+            Action::Zoom(Zoom::In),
             KeyCombo(vec![ModifiedKey(
                 Key::from(VirtKey::Plus),
                 ctrl_or_command | ModifiersState::SHIFT,
@@ -34,7 +37,7 @@ pub fn defaults() -> Vec<(Action, KeyCombo)> {
         ),
         // Zoom out: Ctrl+- / Command+-
         (
-            Action::ZoomOut,
+            Action::Zoom(Zoom::Out),
             KeyCombo(vec![ModifiedKey(
                 Key::from(VirtKey::Minus),
                 ctrl_or_command,
@@ -42,36 +45,60 @@ pub fn defaults() -> Vec<(Action, KeyCombo)> {
         ),
         // Zoom reset: Ctrl+= / Command+=
         (
-            Action::ZoomReset,
+            Action::Zoom(Zoom::Reset),
             KeyCombo(vec![ModifiedKey(
                 Key::from(VirtKey::Equals),
                 ctrl_or_command,
             )]),
         ),
         // Scroll up: Up-arrow
-        (Action::ScrollUp, KeyCombo::from(VirtKey::Up)),
+        (
+            Action::Scroll(VertDirection::Up),
+            KeyCombo::from(VirtKey::Up),
+        ),
         // Scroll down: Down-arrow
-        (Action::ScrollDown, KeyCombo::from(VirtKey::Down)),
+        (
+            Action::Scroll(VertDirection::Down),
+            KeyCombo::from(VirtKey::Down),
+        ),
         // Page up: PageUp
-        (Action::PageUp, KeyCombo::from(VirtKey::PageUp)),
+        (
+            Action::Page(VertDirection::Up),
+            KeyCombo::from(VirtKey::PageUp),
+        ),
         // Page down: PageDown
-        (Action::PageDown, KeyCombo::from(VirtKey::PageDown)),
+        (
+            Action::Page(VertDirection::Down),
+            KeyCombo::from(VirtKey::PageDown),
+        ),
         // Go to top of doc: Home
-        (Action::ToTop, KeyCombo::from(VirtKey::Home)),
+        (
+            Action::ToEdge(VertDirection::Up),
+            KeyCombo::from(VirtKey::Home),
+        ),
         // Go to bottom of doc: End
-        (Action::ToBottom, KeyCombo::from(VirtKey::End)),
+        (
+            Action::ToEdge(VertDirection::Down),
+            KeyCombo::from(VirtKey::End),
+        ),
         // Quit: Esc
         (Action::Quit, KeyCombo::from(VirtKey::Escape)),
         // vim-like bindings
         // Copy: y
         (Action::Copy, KeyCombo::from(VirtKey::Y)),
         // Scroll up: k
-        (Action::ScrollUp, KeyCombo::from(VirtKey::K)),
+        (
+            Action::Scroll(VertDirection::Up),
+            KeyCombo::from(VirtKey::K),
+        ),
         // Scroll down: j
-        (Action::ScrollDown, KeyCombo::from(VirtKey::J)),
+        (
+            Action::Scroll(VertDirection::Down),
+            KeyCombo::from(VirtKey::J),
+        ),
         // Go to top of doc: gg
         (
-            Action::ToTop,
+            Action::ToEdge(VertDirection::Up),
             KeyCombo(vec![
                 ModifiedKey::from(VirtKey::G),
                 ModifiedKey::from(VirtKey::G),
@@ -79,7 +106,7 @@ pub fn defaults() -> Vec<(Action, KeyCombo)> {
         ),
         // Go to bottom of doc: G
         (
-            Action::ToBottom,
+            Action::ToEdge(VertDirection::Down),
             KeyCombo(vec![ModifiedKey(
                 Key::from(VirtKey::G),
                 ModifiersState::SHIFT,

--- a/src/keybindings/mod.rs
+++ b/src/keybindings/mod.rs
@@ -1,3 +1,4 @@
+pub mod action;
 mod defaults;
 mod mappings;
 mod serialization;
@@ -5,6 +6,8 @@ mod serialization;
 mod tests;
 
 use std::{collections::BTreeMap, fmt, slice::Iter, str::FromStr, vec::IntoIter};
+
+use action::Action;
 
 use serde::Deserialize;
 use winit::event::{ModifiersState, ScanCode, VirtualKeyCode};
@@ -159,21 +162,6 @@ impl From<VirtualKeyCode> for KeyCombo {
     fn from(key_code: VirtualKeyCode) -> Self {
         KeyCombo(vec![ModifiedKey::from(key_code)])
     }
-}
-
-#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Action {
-    ToTop,
-    ToBottom,
-    ScrollUp,
-    ScrollDown,
-    PageUp,
-    PageDown,
-    ZoomIn,
-    ZoomOut,
-    ZoomReset,
-    Copy,
-    Quit,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/keybindings/serialization.rs
+++ b/src/keybindings/serialization.rs
@@ -1,9 +1,50 @@
 use std::str::FromStr;
 
-use super::{Key, KeyCombo, ModifiedKey};
+use super::{
+    action::{Action, VertDirection, Zoom},
+    Key, KeyCombo, ModifiedKey,
+};
 
 use serde::{de, Deserialize, Deserializer};
 use winit::event::ModifiersState;
+
+impl<'de> Deserialize<'de> for Action {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        enum FlatAction {
+            ToTop,
+            ToBottom,
+            ScrollUp,
+            ScrollDown,
+            PageUp,
+            PageDown,
+            ZoomIn,
+            ZoomOut,
+            ZoomReset,
+            Copy,
+            Quit,
+        }
+
+        let action = match FlatAction::deserialize(deserializer)? {
+            FlatAction::ToTop => Action::ToEdge(VertDirection::Up),
+            FlatAction::ToBottom => Action::ToEdge(VertDirection::Down),
+            FlatAction::ScrollUp => Action::Scroll(VertDirection::Up),
+            FlatAction::ScrollDown => Action::Scroll(VertDirection::Down),
+            FlatAction::PageUp => Action::Page(VertDirection::Up),
+            FlatAction::PageDown => Action::Page(VertDirection::Down),
+            FlatAction::ZoomIn => Action::Zoom(Zoom::In),
+            FlatAction::ZoomOut => Action::Zoom(Zoom::Out),
+            FlatAction::ZoomReset => Action::Zoom(Zoom::Reset),
+            FlatAction::Copy => Action::Copy,
+            FlatAction::Quit => Action::Quit,
+        };
+
+        Ok(action)
+    }
+}
 
 impl<'de> Deserialize<'de> for Key {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/keybindings/tests.rs
+++ b/src/keybindings/tests.rs
@@ -1,4 +1,7 @@
-use super::{Action, Key, KeyCombo, KeyCombos, ModifiedKey, Keybindings};
+use super::{
+    action::{Action, VertDirection},
+    Key, KeyCombo, KeyCombos, Keybindings, ModifiedKey,
+};
 
 use serde::Deserialize;
 use winit::event::{ModifiersState, VirtualKeyCode};
@@ -30,12 +33,21 @@ inner = [
 
     // Invalid combo 'gG' where the key that broke us out is a singlekey combo
     assert!(key_combos.munch(g).is_none());
-    assert_eq!(Action::ToBottom, key_combos.munch(cap_g).unwrap());
+    assert_eq!(
+        Action::ToEdge(VertDirection::Down),
+        key_combos.munch(cap_g).unwrap()
+    );
 
     // Valid combo 'gj' that shares a branch with 'gg'
     assert!(key_combos.munch(g).is_none());
-    assert_eq!(Action::ScrollDown, key_combos.munch(j).unwrap());
+    assert_eq!(
+        Action::Scroll(VertDirection::Down),
+        key_combos.munch(j).unwrap()
+    );
 
     // Valid singlekey combo for a shared action
-    assert_eq!(Action::ScrollDown, key_combos.munch(j).unwrap());
+    assert_eq!(
+        Action::Scroll(VertDirection::Down),
+        key_combos.munch(j).unwrap()
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use crate::table::Table;
 use crate::text::Text;
 
 use crate::image::ImageData;
-use keybindings::{Action, Key, KeyCombos, ModifiedKey};
+use keybindings::{action::Action, Key, KeyCombos, ModifiedKey};
 use opts::Args;
 use opts::Config;
 use positioner::Positioned;


### PR DESCRIPTION
This avoids a lot of the `unreachable!()`s in `main.rs` while pushing most of the complexity off on `serde`