### PR TITLE
Default light theme to modified `InspiredGitHub`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.16",
 ]
 
 [[package]]

--- a/src/color.rs
+++ b/src/color.rs
@@ -57,7 +57,7 @@ pub const LIGHT_DEFAULT: Theme = Theme {
     link_color: 0x5466FF,
     select_color: 0xCDE8F0,
     checkbox_color: 0x96ECAE,
-    code_highlighter: SyntaxTheme::Base16OceanLight,
+    code_highlighter: SyntaxTheme::InspiredGithub,
 };
 
 #[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/color.rs
+++ b/src/color.rs
@@ -57,7 +57,7 @@ pub const LIGHT_DEFAULT: Theme = Theme {
     link_color: 0x5466FF,
     select_color: 0xCDE8F0,
     checkbox_color: 0x96ECAE,
-    code_highlighter: SyntaxTheme::InspiredGithub,
+    code_highlighter: SyntaxTheme::Base16OceanLight,
 };
 
 #[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -106,14 +106,14 @@ mod html {
 }
 
 #[derive(Default, PartialEq, Eq)]
-pub enum FontWeight {
+enum FontWeight {
     #[default]
     Normal,
     Bold,
 }
 
 impl FontWeight {
-    pub fn new(s: &str) -> Self {
+    fn new(s: &str) -> Self {
         match s {
             "bold" => Self::Bold,
             _ => Self::default(),
@@ -122,14 +122,14 @@ impl FontWeight {
 }
 
 #[derive(Default, PartialEq, Eq)]
-pub enum FontStyle {
+enum FontStyle {
     #[default]
     Normal,
     Italic,
 }
 
 impl FontStyle {
-    pub fn new(s: &str) -> Self {
+    fn new(s: &str) -> Self {
         match s {
             "italic" => Self::Italic,
             _ => Self::default(),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -841,6 +841,9 @@ impl TokenSink for HtmlInterpreter {
                         if self.state.span_weight == FontWeight::Bold {
                             text = text.make_bold(true);
                         }
+                        if self.state.span_style == FontStyle::Italic {
+                            text = text.make_italic(true);
+                        }
                         //.with_size(18.)
                     }
                     for elem in self.state.element_stack.iter().rev() {
@@ -855,14 +858,10 @@ impl TokenSink for HtmlInterpreter {
                         text = text
                             .with_color(native_color(self.theme.link_color, &self.surface_format));
                     }
-                    if self.state.text_options.bold >= 1
-                        || self.state.span_weight == FontWeight::Bold
-                    {
+                    if self.state.text_options.bold >= 1 {
                         text = text.make_bold(true);
                     }
-                    if self.state.text_options.italic >= 1
-                        || self.state.span_style == FontStyle::Italic
-                    {
+                    if self.state.text_options.italic >= 1 {
                         text = text.make_italic(true);
                     }
                     if self.state.text_options.underline >= 1 {


### PR DESCRIPTION
Looks like we both ended up making pretty similar changes :laughing: 

This switches the default theme to `InspiredGitHub`, adds support for `font-style` since the code highlighting also makes use of that, and overrides the background color to match the background color used by GitHub