### PR TITLE
Make correct location of `inlyne.toml` file clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Use `inlyne --help` to see all the command line options. Some of which can be se
 
 - Linux: `/home/alice/.config/inlyne/inlyne.toml`
 - Windows: `C:\Users\Alice\AppData\Roaming\inlyne\inlyne.toml`
-- Mac: /Users/Alice/Library/Application Support/inlyne/inlyne.toml`
+- Mac: `/Users/Alice/Library/Application Support/inlyne/inlyne.toml`
 
 Checkout `inlyne.sample.toml` for an example configuration.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,13 @@ You weren't supposed to see this!
 
 ## Configuration
 
-Use `inlyne --help` to see all the command line options. Some of which can be set permentantly by placing an `inlyne.toml` file into the default [dirs](https://crates.io/crates/dirs) configuration folder for your respective OS. Checkout `inlyne.sample.toml` for an example configuration.
+Use `inlyne --help` to see all the command line options. Some of which can be set permentantly by placing an `inlyne.toml` file into a directory called `inlyne` within the default [dirs](https://crates.io/crates/dirs) configuration folder for your respective OS:
+
+- Linux: `/home/alice/.config/inlyne/inlyne.toml`
+- Windows: `C:\Users\Alice\AppData\Roaming\inlyne\inlyne.toml`
+- Mac: /Users/Alice/Library/Application Support/inlyne/inlyne.toml`
+
+Checkout `inlyne.sample.toml` for an example configuration.
 
 ## FAQ
 


### PR DESCRIPTION
I had to look up the `dirs` documentation to work out where the config directory was on macOS, and I had to look through the inlyne source code to determine that the file was nested under a directory called `inlyne`.