### PR TITLE
Properly modify InspiredGitHub's background color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "resvg",
  "serde",
  "serde_yaml",
+ "syntect",
  "tiny-skia 0.9.1",
  "toml",
  "twox-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ indexmap = { version = "1.9.3", features = ["serde"] }
 html-escape = "0.2.13"
 fxhash = "0.2.1"
 twox-hash = "1.6.3"
+syntect = "5.0.0"
 
 [dependencies.glyphon]
 version = "0.2"

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -517,14 +517,7 @@ impl TokenSink for HtmlInterpreter {
                                         .split(';')
                                         .find_map(|style| style.strip_prefix("background-color:#"))
                                     {
-                                        if let Ok(mut hex) = u32::from_str_radix(hex_str, 16) {
-                                            // HACK: override `inspired-github`'s background color.
-                                            // It looks like this is made for an editor theme where
-                                            // full white makes more sense for a background.
-                                            // Default to github's background color instead;
-                                            if hex == 0xffffff {
-                                                hex = 0xf6f8fa;
-                                            }
+                                        if let Ok(hex) = u32::from_str_radix(hex_str, 16) {
                                             let bg_color = native_color(hex, &self.surface_format);
                                             self.current_textbox
                                                 .set_background_color(Some(bg_color));


### PR DESCRIPTION
This properly handles modifying Inspired GitHub's background color without the hack in the interpreter

The themes in a `ThemeSet` are just stored in `BTreeMap`, so we could always choose to load in our own default `inlyne-light` and `inlyne-dark` themes if desired