### PR TITLE
Add support for custom syntax themes

### DIFF
--- a/inlyne.default.toml
+++ b/inlyne.default.toml
@@ -45,6 +45,9 @@ checkbox-color = 0x0a5301
 #     "base16-ocean-light", "inspired-github",      "solarized-dark",
 #     "solarized-light"
 # ]
+# You can also pass a path to a `.tmTheme` file for a custom theme instead
+# Example:
+# code-highlighter.path = "/path/to/custom.tmTheme"
 code-highlighter = "base16-ocean-dark"
 
 # And the same settings are available for the light theme as well

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,12 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use crate::utils;
+
+use anyhow::Context;
 use serde::Deserialize;
+use syntect::highlighting::{
+    Color as SyntectColor, Theme as SyntectTheme, ThemeSet as SyntectThemeSet,
+};
 use wgpu::TextureFormat;
 
 fn hex_to_linear_rgba(c: u32) -> [f32; 4] {
@@ -23,7 +31,7 @@ pub fn native_color(c: u32, format: &TextureFormat) -> [f32; 4] {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct Theme {
     pub text_color: u32,
     pub background_color: u32,
@@ -33,36 +41,105 @@ pub struct Theme {
     pub link_color: u32,
     pub select_color: u32,
     pub checkbox_color: u32,
-    pub code_highlighter: SyntaxTheme,
+    pub code_highlighter: SyntectTheme,
 }
 
-pub const DARK_DEFAULT: Theme = Theme {
-    text_color: 0x9DACBB,
-    background_color: 0x1A1D22,
-    code_color: 0xB38FAC,
-    code_block_color: 0x181C21,
-    quote_block_color: 0x1D2025,
-    link_color: 0x4182EB,
-    select_color: 0x3675CB,
-    checkbox_color: 0x0A5301,
-    code_highlighter: SyntaxTheme::Base16OceanDark,
-};
+impl Theme {
+    pub fn dark_default() -> Self {
+        Self {
+            text_color: 0x9DACBB,
+            background_color: 0x1A1D22,
+            code_color: 0xB38FAC,
+            code_block_color: 0x181C21,
+            quote_block_color: 0x1D2025,
+            link_color: 0x4182EB,
+            select_color: 0x3675CB,
+            checkbox_color: 0x0A5301,
+            code_highlighter: SyntectTheme::from(ThemeDefaults::Base16OceanDark),
+        }
+    }
 
-pub const LIGHT_DEFAULT: Theme = Theme {
-    text_color: 0x000000,
-    background_color: 0xFFFFFF,
-    code_color: 0x95114E,
-    code_block_color: 0xEAEDF3,
-    quote_block_color: 0xEEF9FE,
-    link_color: 0x5466FF,
-    select_color: 0xCDE8F0,
-    checkbox_color: 0x96ECAE,
-    code_highlighter: SyntaxTheme::InspiredGithub,
-};
+    pub fn light_default() -> Self {
+        Self {
+            text_color: 0x000000,
+            background_color: 0xFFFFFF,
+            code_color: 0x95114E,
+            code_block_color: 0xEAEDF3,
+            quote_block_color: 0xEEF9FE,
+            link_color: 0x5466FF,
+            select_color: 0xCDE8F0,
+            checkbox_color: 0x96ECAE,
+            code_highlighter: SyntectTheme::from(ThemeDefaults::InspiredGithub),
+        }
+    }
+}
+
+// TODO(cosmic): replace with derive after syntect theme impls PartialEq
+impl PartialEq for Theme {
+    fn eq(&self, other: &Self) -> bool {
+        let Self {
+            text_color: self_text_color,
+            background_color: self_background_color,
+            code_color: self_code_color,
+            code_block_color: self_code_block_color,
+            quote_block_color: self_quote_block_color,
+            link_color: self_link_color,
+            select_color: self_select_color,
+            checkbox_color: self_checkbox_color,
+            code_highlighter: self_code_highlighter,
+        } = self;
+        let Self {
+            text_color: other_text_color,
+            background_color: other_background_color,
+            code_color: other_code_color,
+            code_block_color: other_code_block_color,
+            quote_block_color: other_quote_block_color,
+            link_color: other_link_color,
+            select_color: other_select_color,
+            checkbox_color: other_checkbox_color,
+            code_highlighter: other_code_highlighter,
+        } = other;
+
+        self_text_color == other_text_color
+            && self_background_color == other_background_color
+            && self_code_color == other_code_color
+            && self_code_block_color == other_code_block_color
+            && self_quote_block_color == other_quote_block_color
+            && self_link_color == other_link_color
+            && self_select_color == other_select_color
+            && self_checkbox_color == other_checkbox_color
+            && utils::SyntectThemePartialEq(self_code_highlighter)
+                == utils::SyntectThemePartialEq(other_code_highlighter)
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum SyntaxTheme {
+    Defaults(ThemeDefaults),
+    Custom { path: PathBuf },
+}
+
+impl TryFrom<SyntaxTheme> for SyntectTheme {
+    type Error = anyhow::Error;
+
+    fn try_from(syntax_theme: SyntaxTheme) -> Result<Self, Self::Error> {
+        match syntax_theme {
+            SyntaxTheme::Defaults(default) => Ok(SyntectTheme::from(default)),
+            SyntaxTheme::Custom { path } => {
+                let mut reader = BufReader::new(File::open(&path).with_context(|| {
+                    format!("Failed opening theme from path {}", path.display())
+                })?);
+                SyntectThemeSet::load_from_reader(&mut reader)
+                    .with_context(|| format!("Failed loading theme from path {}", path.display()))
+            }
+        }
+    }
+}
 
 #[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum SyntaxTheme {
+pub enum ThemeDefaults {
     Base16OceanDark,
     Base16EightiesDark,
     Base16MochaDark,
@@ -72,7 +149,7 @@ pub enum SyntaxTheme {
     SolarizedLight,
 }
 
-impl SyntaxTheme {
+impl ThemeDefaults {
     pub fn as_syntect_name(self) -> &'static str {
         match self {
             Self::Base16OceanDark => "base16-ocean.dark",
@@ -83,5 +160,29 @@ impl SyntaxTheme {
             Self::SolarizedDark => "Solarized (dark)",
             Self::SolarizedLight => "Solarized (light)",
         }
+    }
+}
+
+impl From<ThemeDefaults> for SyntectTheme {
+    fn from(default: ThemeDefaults) -> Self {
+        let mut default_themes = SyntectThemeSet::load_defaults();
+        let mut theme = default_themes
+            .themes
+            .remove(default.as_syntect_name())
+            .expect("Included with defaults");
+
+        // InspiredGitHub's background color is 0xfff which is the same as the default light theme
+        // background. We match GitHub's light theme code blocks instead to distinguish code blocks
+        // from the background
+        if default == ThemeDefaults::InspiredGithub {
+            theme.settings.background = Some(SyntectColor {
+                r: 0xf6,
+                g: 0xf8,
+                b: 0xfa,
+                a: u8::MAX,
+            });
+        }
+
+        theme
     }
 }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -202,7 +202,7 @@ impl HtmlInterpreter {
         let mut input = BufferQueue::new();
 
         let span_color = native_color(self.theme.code_color, &self.surface_format);
-        let code_highlighter = self.theme.code_highlighter;
+        let code_highlighter = self.theme.code_highlighter.clone();
         let mut tok = Tokenizer::new(self, TokenizerOpts::default());
 
         for md_string in receiver {
@@ -217,7 +217,7 @@ impl HtmlInterpreter {
                 };
                 tok.sink.current_textbox = TextBox::new(Vec::new(), tok.sink.hidpi_scale);
                 tok.sink.stopped = false;
-                let htmlified = markdown_to_html(&md_string, code_highlighter);
+                let htmlified = markdown_to_html(&md_string, code_highlighter.clone());
 
                 input.push_back(
                     Tendril::from_str(&htmlified)

--- a/src/main.rs
+++ b/src/main.rs
@@ -766,7 +766,7 @@ fn main() -> anyhow::Result<()> {
             Config::default()
         }),
     };
-    let opts = Opts::parse_and_load_from(args, config);
+    let opts = Opts::parse_and_load_from(args, config)?;
     let inlyne = Inlyne::new(opts)?;
 
     inlyne.spawn_watcher();

--- a/tests/assets/sample.tmTheme
+++ b/tests/assets/sample.tmTheme
@@ -1,0 +1,60 @@
+<!--
+Barebones theme from:
+https://www.sublimetext.com/docs/color_schemes_tmtheme.html
+-->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Example Color Scheme</string>
+    <key>settings</key>
+    <array>
+        <!-- Global settings -->
+        <dict>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#222222</string>
+                <key>foreground</key>
+                <string>#EEEEEE</string>
+                <key>caret</key>
+                <string>#FFFFFF</string>
+            </dict>
+        </dict>
+        <!-- Scope styles -->
+        <dict>
+            <key>name</key>
+            <string>Comment</string>
+            <key>scope</key>
+            <string>comment</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#888888</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>String</string>
+            <key>scope</key>
+            <string>string</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#FFD500</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Number</string>
+            <key>scope</key>
+            <string>constant.numeric</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#7F00FF</string>
+            </dict>
+        </dict>
+    </array>
+</dict>


### PR DESCRIPTION
The recent syntect plugin work had me thinking about how much work it would be to allow for custom themes outside of the ones bundled with syntect. Turns out the answer is not _too_ much, but there's definitely some changes I want to submit upstream for `comrak` and `syntect`

This allows for specifying custom themes by passing a `.tmTheme` file like so

```toml
[dark-theme]
code-highlighter.path = "/path/to/theme.tmTheme"
```

while still supporting the old method for specifying any of the bundled themes. There was a lot of reworking to pass around the actual syntect `Theme` instead of the enum specifying which bundled theme to use, but other than that the changes were pretty simple

## Demo

When using a slightly modified (this theme could use a lot more work though):

https://github.com/rose-pine/sublime-text/blob/main/rose-pine.tmTheme

![image](https://github.com/trimental/inlyne/assets/30302768/b40231af-5785-4f4c-b74c-5a39b49e8181)
