### PR TITLE
Fix footnote numbered list

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -93,7 +93,6 @@ mod html {
 
     pub enum Element {
         List(List),
-        ListItem,
         Input,
         Table(Table),
         TableRow(Vec<TextBox>),
@@ -148,6 +147,7 @@ struct State {
     // Stores the row and a counter of newlines after each image
     inline_images: Option<(Row, usize)>,
     pending_anchor: Option<String>,
+    pending_list_prefix: Option<String>,
 }
 
 pub struct HtmlInterpreter {
@@ -458,11 +458,35 @@ impl TokenSink for HtmlInterpreter {
                         "bold" | "strong" => self.state.text_options.bold += 1,
                         "code" => self.state.text_options.code += 1,
                         "li" => {
-                            self.state.element_stack.push(html::Element::ListItem);
                             for Attribute { name, value } in tag.attrs {
                                 if name.local == local_name!("id") {
                                     let anchor_name = format!("#{}", value);
                                     self.state.pending_anchor = Some(anchor_name);
+                                }
+                            }
+
+                            // Push a pending list prefix based on the list type
+                            let mut list = None;
+                            for element in self.state.element_stack.iter_mut().rev() {
+                                if let html::Element::List(html_list) = element {
+                                    list = Some(html_list);
+                                }
+                            }
+                            let list = list.expect("List ended unexpectedly");
+                            if self.current_textbox.texts.is_empty() {
+                                if let html::List {
+                                    list_type: html::ListType::Ordered(index),
+                                    ..
+                                } = list
+                                {
+                                    self.state.pending_list_prefix = Some(format!("{}. ", index));
+                                    *index += 1;
+                                } else if let html::List {
+                                    list_type: html::ListType::Unordered,
+                                    ..
+                                } = list
+                                {
+                                    self.state.pending_list_prefix = Some("· ".to_owned());
                                 }
                             }
                         }
@@ -690,7 +714,6 @@ impl TokenSink for HtmlInterpreter {
                             let _ = self.state.pending_anchor.take();
 
                             self.push_current_textbox();
-                            self.state.element_stack.pop();
                         }
                         "input" => {
                             self.push_current_textbox();
@@ -802,44 +825,16 @@ impl TokenSink for HtmlInterpreter {
                         self.hidpi_scale,
                         native_color(self.theme.text_color, &self.surface_format),
                     );
-                    if let Some(html::Element::ListItem) = self.state.element_stack.last() {
-                        let mut list = None;
-                        for element in self.state.element_stack.iter_mut().rev() {
-                            if let html::Element::List(html_list) = element {
-                                list = Some(html_list);
-                            }
-                        }
-                        let list = list.expect("List ended unexpectedly");
-
+                    if let Some(prefix) = self.state.pending_list_prefix.take() {
                         if self.current_textbox.texts.is_empty() {
-                            if let html::List {
-                                list_type: html::ListType::Ordered(index),
-                                ..
-                            } = list
-                            {
-                                self.current_textbox.texts.push(
-                                    Text::new(
-                                        format!("{}. ", index),
-                                        self.hidpi_scale,
-                                        native_color(self.theme.text_color, &self.surface_format),
-                                    )
-                                    .make_bold(true),
-                                );
-                                *index += 1;
-                            } else if let html::List {
-                                list_type: html::ListType::Unordered,
-                                ..
-                            } = list
-                            {
-                                self.current_textbox.texts.push(
-                                    Text::new(
-                                        "· ".to_string(),
-                                        self.hidpi_scale,
-                                        native_color(self.theme.text_color, &self.surface_format),
-                                    )
-                                    .make_bold(true),
+                            self.current_textbox.texts.push(
+                                Text::new(
+                                    prefix,
+                                    self.hidpi_scale,
+                                    native_color(self.theme.text_color, &self.surface_format),
                                 )
-                            }
+                                .make_bold(true),
+                            );
                         }
                     }
                     if self.state.text_options.block_quote >= 1 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,14 +534,14 @@ impl Inlyne {
                                                 .send_event(InlyneEvent::FileReload)
                                                 .expect("new file to reload successfully");
                                         }
-                                    } else if open::that(link).is_err() {
-                                        if let Some(anchor_pos) =
-                                            self.renderer.positioner.anchors.get(link)
-                                        {
-                                            self.renderer.set_scroll_y(*anchor_pos);
-                                            self.window.request_redraw();
-                                            self.window.set_cursor_icon(CursorIcon::Default);
-                                        }
+                                    } else if let Some(anchor_pos) =
+                                        self.renderer.positioner.anchors.get(link)
+                                    {
+                                        self.renderer.set_scroll_y(*anchor_pos);
+                                        self.window.request_redraw();
+                                        self.window.set_cursor_icon(CursorIcon::Default);
+                                    } else {
+                                        open::that(link).unwrap();
                                     }
                                 } else if self.renderer.selection.is_none() {
                                     // Only set selection when not over link


### PR DESCRIPTION
_Probably best to review the two commits separately. This probably should have been two PRs, but here we are :sweat_smile:_

The issue was that the code for pushing the list prefix would only check the last element pushed in the `element_stack` when processing `CharacterTokens(_)`, but the footnote reference generates the following HTML

```html
<section class="footnotes" data-footnotes>
    <ol>
        <li id="fn-1">
            <p>A <a href="https://www.markdownguide.org/extended-syntax/#footnotes">footnote</a> <a href="#fnref-1" class="footnote-backref" data-footnote-backref aria-label="Back to content">↩</a></p>
        </li>
    </ol>
</section>
```

which means that a `ListItem` is pushed on followed by a `Paragraph(_)` before hitting any character tokens

This PR changes things to set a `pending_list_prefix` when processing an opening `"li"` element and then checking if `pending_list_prefix` is set in the appropriate place when processing `CharacterTokens(_)` which should handle nesting better. The first commit is just some twiddling to make `HtmlInterpreter` testable since it's a big bundle of mutable state, and I don't want to accidentally regress something. A fun part of this is that the second commit shows how the list prefix is now correctly getting pushed onto the footnote reference

```diff
diff --git a/src/snapshots/inlyne__interpreter__tests__lists_get_prefixed.snap b/src/snapshots/inlyne__interpreter__tests__lists_get_prefixed.snap
index d4e5391..f27b437 100644
--- a/src/snapshots/inlyne__interpreter__tests__lists_get_prefixed.snap
+++ b/src/snapshots/inlyne__interpreter__tests__lists_get_prefixed.snap
@@ -75,6 +75,23 @@ expression: finished_queue
             indent: 50.0,
             font_size: 16.0,
             texts: [
+                Text {
+                    text: "1. ",
+                    color: None,
+                    link: None,
+                    is_bold: true,
+                    is_italic: false,
+                    is_underlined: false,
+                    is_striked: false,
+                    font_family: SansSerif,
+                    hidpi_scale: 1.0,
+                    default_color: [
+                        0.0,
+                        0.0,
+                        0.0,
+                        1.0,
+                    ],
+                },
                 Text {
                     text: "First footnote ",
                     color: None,
```

_Side note: The single test added with this PR bumps the line test coverage from 25% to 33% :tada:_

## Demo

```markdown
A footnote[^1]

- Unordered list
- Unordered list

Another footnote[^2]

1. Ordered list
1. Ordered list

[^1]: 1st footnote
[^2]: 2nd footnote
```

![image](https://github.com/trimental/inlyne/assets/30302768/2d9a7bbc-7fee-4f70-abc5-9d5bc65fc578)

It looks like a spacer gets pushed between the footnotes, but that also happens on `main`, so it's not a regression from this PR at least