### PR TITLE
Table Alignment

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -327,8 +327,39 @@ impl TokenSink for HtmlInterpreter {
                             self.current_textbox
                                 .set_quote_block(Some(self.state.text_options.block_quote));
                         }
-                        "th" => self.state.text_options.bold += 1,
-                        "td" => {}
+                        "th" => {
+                            self.state.text_options.bold += 1;
+                            let align = tag
+                                .attrs
+                                .iter()
+                                .find(|attr| attr.name.local == local_name!("align"))
+                                .map(|attr| match attr.value.to_string().as_str() {
+                                    "left" => Some(Align::Left),
+                                    "center" => Some(Align::Center),
+                                    "right" => Some(Align::Right),
+                                    _ => None,
+                                })
+                                .unwrap_or_default();
+                            if let Some(align) = align {
+                                self.current_textbox.set_align(align);
+                            }
+                        }
+                        "td" => {
+                            let align = tag
+                                .attrs
+                                .iter()
+                                .find(|attr| attr.name.local == local_name!("align"))
+                                .map(|attr| match attr.value.to_string().as_str() {
+                                    "left" => Some(Align::Left),
+                                    "center" => Some(Align::Center),
+                                    "right" => Some(Align::Right),
+                                    _ => None,
+                                })
+                                .unwrap_or_default();
+                            if let Some(align) = align {
+                                self.current_textbox.set_align(align);
+                            }
+                        }
                         "table" => {
                             self.push_spacer();
                             self.state


### PR DESCRIPTION
Adds table item horizontal alignment as shown below:

![image](https://github.com/trimental/inlyne/assets/40879396/ba31d2d3-9c36-464d-85ba-5a8e95c17131)

Looks like wrapping is still occurring in some weird places, might just be some f32 nonsense with the bounds changing slightly between rendering and layingout