### PR TITLE
CLI testing tweaks

### DIFF
--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -96,8 +96,22 @@ impl Args {
     }
 
     pub fn parse_from(args: Vec<OsString>) -> Self {
+        #[cfg(test)]
+        {
+            let _ = args;
+            panic!("Use `Args::try_parse_from()` in tests");
+        }
+        #[cfg(not(test))]
+        match Self::try_parse_from(args) {
+            Ok(args) => args,
+            // Expose clap error normally
+            Err(clap_err) => clap_err.exit(),
+        }
+    }
+
+    pub fn try_parse_from(args: Vec<OsString>) -> Result<Self, clap::Error> {
         let c = command();
-        let matches = c.get_matches_from(args);
+        let matches = c.try_get_matches_from(args)?;
 
         let file_path = matches.get_one("file").cloned().unwrap();
         let theme = matches.get_one("theme").cloned();
@@ -105,12 +119,12 @@ impl Args {
         let config = matches.get_one("config").cloned();
         let page_width = matches.get_one("page_width").cloned();
 
-        Self {
+        Ok(Self {
             file_path,
             theme,
             scale,
             config,
             page_width,
-        }
+        })
     }
 }

--- a/src/opts/tests.rs
+++ b/src/opts/tests.rs
@@ -231,3 +231,9 @@ fn custom_syntax_theme() {
         "Example Color Scheme"
     );
 }
+
+#[test]
+fn missing_file_arg() {
+    // A file arg should be required
+    assert!(Args::try_parse_from(gen_args(Vec::new())).is_err());
+}

--- a/src/opts/tests.rs
+++ b/src/opts/tests.rs
@@ -47,7 +47,7 @@ fn debug_assert() {
 fn defaults() {
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(gen_args(vec!["file.md"])),
+            Args::try_parse_from(gen_args(vec!["file.md"])).unwrap(),
             config::Config::default(),
             ResolvedTheme::Light,
         )
@@ -65,7 +65,7 @@ fn config_overrides_default() {
     };
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(gen_args(vec!["file.md"])),
+            Args::try_parse_from(gen_args(vec!["file.md"])).unwrap(),
             config,
             ResolvedTheme::Light,
         )
@@ -83,7 +83,7 @@ fn config_overrides_default() {
     };
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(gen_args(vec!["file.md"])),
+            Args::try_parse_from(gen_args(vec!["file.md"])).unwrap(),
             config,
             ResolvedTheme::Dark,
         )
@@ -100,7 +100,7 @@ fn config_overrides_default() {
     };
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(gen_args(vec!["file.md"])),
+            Args::try_parse_from(gen_args(vec!["file.md"])).unwrap(),
             config,
             ResolvedTheme::Light,
         )
@@ -116,7 +116,7 @@ fn config_overrides_default() {
 fn from_cli() {
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(gen_args(vec!["--theme", "dark", "file.md"])),
+            Args::try_parse_from(gen_args(vec!["--theme", "dark", "file.md"])).unwrap(),
             config::Config::default(),
             ResolvedTheme::Light,
         )
@@ -135,7 +135,7 @@ fn from_cli() {
     };
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(gen_args(vec!["--scale", "1.5", "file.md"])),
+            Args::try_parse_from(gen_args(vec!["--scale", "1.5", "file.md"])).unwrap(),
             config,
             ResolvedTheme::Light,
         )
@@ -160,7 +160,7 @@ fn cli_kitchen_sink() {
     ]);
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
-            Args::parse_from(args),
+            Args::try_parse_from(args).unwrap(),
             config::Config::default(),
             ResolvedTheme::Light,
         )
@@ -183,7 +183,7 @@ fn builtin_syntax_theme() {
     });
 
     let opts = Opts::parse_and_load_with_system_theme(
-        Args::parse_from(gen_args(vec!["file.md"])),
+        Args::try_parse_from(gen_args(vec!["file.md"])).unwrap(),
         config,
         ResolvedTheme::Light,
     )
@@ -206,7 +206,7 @@ fn custom_syntax_theme() {
         config
     }
 
-    let args = Args::parse_from(gen_args(vec!["file.md"]));
+    let args = Args::try_parse_from(gen_args(vec!["file.md"])).unwrap();
 
     let res = Opts::parse_and_load_with_system_theme(
         args.clone(),


### PR DESCRIPTION
Followup to #143

I think the arg parsing regression was from changing the required args for adding the shell completions flag, and then subsequently dropping the shell completions flag

This also fixes the CLI arg parsing tests to catch `clap` errors instead of exposing the error message to stdout/stderr