### PR TITLE
Removed unused `clap_complete` dep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ cargo insta review
 _If you're wondering 'Is this relevant to me?' Then the answer is probably no
 ;P_
 
+- [ ] Check for unused dependencies
+  - `$ cargo +nightly udeps`
 - [ ] Update static assets
   - `$ cargo xtask gen`
 - [ ] Update `rust-version` in `Cargo.toml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,7 +1735,6 @@ dependencies = [
  "anyhow",
  "bytemuck",
  "clap",
- "clap_complete",
  "comrak",
  "copypasta",
  "dark-light",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ memmap2 = "0.6.1"
 log = "0.4.17"
 env_logger = "0.10.0"
 notify = "6.0.0"
-clap_complete = "4.3.1"
 dark-light = "1.0.0"
 # We only decompress our own compressed data, so disable `safe-decode` and
 # `checked-decode`


### PR DESCRIPTION
Moving shell completion generation to an `xtask` left this dependency unused