### PR TITLE
More robust file watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "dark-light",
  "dirs 5.0.1",
  "env_logger",
+ "filetime",
  "fxhash",
  "glyphon",
  "html-escape",
@@ -1762,6 +1763,7 @@ dependencies = [
  "serde_yaml",
  "syntect",
  "taffy",
+ "tempfile",
  "tiny-skia",
  "toml",
  "twox-hash",
@@ -3670,15 +3672,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ inherits = "release"
 lto = true
 
 [dev-dependencies]
+filetime = "0.2.21"
 insta = "1.29.0"
 pretty_assertions = "1.3.0"
+tempfile = "3.6.0"
 wiremock = "0.5.18"

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,7 @@ fn root_filepath_to_vcs_dir(path: &Path) -> Option<PathBuf> {
 }
 
 impl Inlyne {
+    // TODO: doesn't follow watching file after file changes. Need to coordinate that
     pub fn spawn_watcher(&self) {
         // Create a channel to receive the events.
         let (watch_tx, watch_rx) = channel();

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -12,6 +12,9 @@ use notify::{
 };
 use winit::event_loop::EventLoopProxy;
 
+#[cfg(test)]
+mod tests;
+
 trait Callback: Send + 'static {
     fn update(&self);
 }

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1,14 +1,18 @@
-use std::{path::PathBuf, sync::mpsc::channel, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::mpsc,
+    time::Duration,
+};
 
-use crate::{Inlyne, InlyneEvent};
+use crate::InlyneEvent;
 
 use notify::{
     event::{EventKind, ModifyKind},
-    RecommendedWatcher, RecursiveMode, Watcher,
+    Event, EventHandler, RecommendedWatcher, RecursiveMode, Watcher as _,
 };
 use winit::event_loop::EventLoopProxy;
 
-trait Callback {
+trait Callback: Send + 'static {
     fn update(&self);
 }
 
@@ -18,69 +22,104 @@ impl Callback for EventLoopProxy<InlyneEvent> {
     }
 }
 
-pub fn spawn_watcher(inlyne: &Inlyne) {
-    let event_proxy = inlyne.event_loop.create_proxy();
-    let file_path = inlyne.opts.file_path.clone();
-    spawn_watcher_inner(event_proxy, file_path);
+enum WatcherMsg {
+    // Sent by the registered file watcher
+    Notify(notify::Result<Event>),
+    // Sent by the event loop
+    FileChange(PathBuf),
 }
 
-// TODO: doesn't follow watching file after file changes. Need to coordinate that
-fn spawn_watcher_inner<C: Callback + Send + 'static>(reload_callback: C, file_path: PathBuf) {
-    // Create a channel to receive the events.
-    let (watch_tx, watch_rx) = channel();
+struct MsgHandler(mpsc::Sender<WatcherMsg>);
 
-    // Create a watcher object, delivering raw events.
-    // The notification back-end is selected based on the platform.
-    let mut watcher = RecommendedWatcher::new(watch_tx, notify::Config::default()).unwrap();
+impl EventHandler for MsgHandler {
+    fn handle_event(&mut self, event: notify::Result<Event>) {
+        let msg = WatcherMsg::Notify(event);
+        let _ = self.0.send(msg);
+    }
+}
 
-    // Add the file path to be watched.
-    std::thread::spawn(move || {
+pub struct Watcher(mpsc::Sender<WatcherMsg>);
+
+impl Watcher {
+    pub fn spawn(event_proxy: EventLoopProxy<InlyneEvent>, file_path: PathBuf) -> Self {
+        Self::spawn_inner(event_proxy, file_path)
+    }
+
+    fn spawn_inner<C: Callback>(reload_callback: C, file_path: PathBuf) -> Self {
+        let (msg_tx, msg_rx) = mpsc::channel();
+        let watcher = Self(msg_tx.clone());
+
+        let notify_watcher =
+            RecommendedWatcher::new(MsgHandler(msg_tx), notify::Config::default()).unwrap();
+
+        std::thread::spawn(move || {
+            endlessly_handle_messages(notify_watcher, msg_rx, reload_callback, file_path);
+        });
+
         watcher
-            .watch(&file_path, RecursiveMode::NonRecursive)
-            .unwrap();
+    }
+
+    pub fn update_path(&self, new_path: &Path) {
+        let msg = WatcherMsg::FileChange(new_path.to_owned());
+        let _ = self.0.send(msg);
+    }
+}
+
+fn endlessly_handle_messages<C: Callback>(
+    mut watcher: RecommendedWatcher,
+    msg_rx: mpsc::Receiver<WatcherMsg>,
+    reload_callback: C,
+    mut file_path: PathBuf,
+) {
+    watcher
+        .watch(&file_path, RecursiveMode::NonRecursive)
+        .unwrap();
+
+    let poll_registering_watcher = |watcher: &mut RecommendedWatcher, file_path: &Path| {
+        let mut delay = Duration::from_millis(10);
 
         loop {
-            let event = match watch_rx.recv() {
-                Ok(Ok(event)) => event,
-                Ok(Err(err)) => {
-                    log::warn!("File watcher error: {}", err);
-                    continue;
-                }
-                Err(err) => {
-                    log::warn!("File watcher channel dropped unexpectedly: {}", err);
-                    break;
-                }
-            };
+            std::thread::sleep(delay);
+            delay = Duration::from_millis(100);
 
-            log::debug!("File event: {:#?}", event);
-            match event.kind {
-                EventKind::Remove(_) | EventKind::Modify(ModifyKind::Name(_)) => {
-                    // Some editors may remove/rename the file as a part of saving.
-                    // Reregister file watching in this case
+            let _ = watcher.unwatch(file_path);
+            if watcher
+                .watch(file_path, RecursiveMode::NonRecursive)
+                .is_ok()
+            {
+                break;
+            }
+        }
+    };
+
+    while let Ok(msg) = msg_rx.recv() {
+        match msg {
+            WatcherMsg::Notify(Ok(event)) => {
+                log::debug!("File event: {:#?}", event);
+
+                if matches!(
+                    event.kind,
+                    EventKind::Remove(_) | EventKind::Modify(ModifyKind::Name(_))
+                ) {
                     log::debug!("File may have been renamed/removed. Falling back to polling");
-
-                    let mut delay = Duration::from_millis(10);
-                    loop {
-                        std::thread::sleep(delay);
-                        delay = Duration::from_millis(100);
-
-                        let _ = watcher.unwatch(&file_path);
-                        if watcher
-                            .watch(&file_path, RecursiveMode::NonRecursive)
-                            .is_ok()
-                        {
-                            log::debug!("Sucessfully re-registered file watcher");
-                            reload_callback.update();
-                            break;
-                        }
-                    }
-                }
-                EventKind::Modify(_) => {
+                    poll_registering_watcher(&mut watcher, &file_path);
+                    log::debug!("Sucessfully re-registered file watcher");
+                    reload_callback.update();
+                } else if matches!(event.kind, EventKind::Modify(_)) {
                     log::debug!("Reloading file");
                     reload_callback.update();
                 }
-                _ => {}
+            }
+            WatcherMsg::Notify(Err(err)) => log::warn!("File watcher error: {}", err),
+            WatcherMsg::FileChange(new_path) => {
+                log::info!("Updating file watcher path: {}", new_path.display());
+                let _ = watcher.unwatch(&file_path);
+                poll_registering_watcher(&mut watcher, &new_path);
+                file_path = new_path;
+                reload_callback.update();
             }
         }
-    });
+    }
+
+    log::warn!("File watcher channel dropped unexpectedly");
 }

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -106,7 +106,7 @@ fn endlessly_handle_messages<C: Callback>(
                 ) {
                     log::debug!("File may have been renamed/removed. Falling back to polling");
                     poll_registering_watcher(&mut watcher, &file_path);
-                    log::debug!("Sucessfully re-registered file watcher");
+                    log::debug!("Successfully re-registered file watcher");
                     reload_callback.update();
                 } else if matches!(event.kind, EventKind::Modify(_)) {
                     log::debug!("Reloading file");

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -1,0 +1,71 @@
+use std::{sync::mpsc::channel, time::Duration};
+
+use crate::{Inlyne, InlyneEvent};
+
+use notify::{
+    event::{EventKind, ModifyKind},
+    RecommendedWatcher, RecursiveMode, Watcher,
+};
+
+// TODO: doesn't follow watching file after file changes. Need to coordinate that
+pub fn spawn_watcher(inlyne: &Inlyne) {
+    // Create a channel to receive the events.
+    let (watch_tx, watch_rx) = channel();
+
+    // Create a watcher object, delivering raw events.
+    // The notification back-end is selected based on the platform.
+    let mut watcher = RecommendedWatcher::new(watch_tx, notify::Config::default()).unwrap();
+
+    // Add the file path to be watched.
+    let event_proxy = inlyne.event_loop.create_proxy();
+    let file_path = inlyne.opts.file_path.clone();
+    std::thread::spawn(move || {
+        watcher
+            .watch(&file_path, RecursiveMode::NonRecursive)
+            .unwrap();
+
+        loop {
+            let event = match watch_rx.recv() {
+                Ok(Ok(event)) => event,
+                Ok(Err(err)) => {
+                    log::warn!("File watcher error: {}", err);
+                    continue;
+                }
+                Err(err) => {
+                    log::warn!("File watcher channel dropped unexpectedly: {}", err);
+                    break;
+                }
+            };
+
+            log::debug!("File event: {:#?}", event);
+            match event.kind {
+                EventKind::Remove(_) | EventKind::Modify(ModifyKind::Name(_)) => {
+                    // Some editors may remove/rename the file as a part of saving.
+                    // Reregister file watching in this case
+                    log::debug!("File may have been renamed/removed. Falling back to polling");
+
+                    let mut delay = Duration::from_millis(10);
+                    loop {
+                        std::thread::sleep(delay);
+                        delay = Duration::from_millis(100);
+
+                        let _ = watcher.unwatch(&file_path);
+                        if watcher
+                            .watch(&file_path, RecursiveMode::NonRecursive)
+                            .is_ok()
+                        {
+                            log::debug!("Sucessfully re-registered file watcher");
+                            let _ = event_proxy.send_event(InlyneEvent::FileReload);
+                            break;
+                        }
+                    }
+                }
+                EventKind::Modify(_) => {
+                    log::debug!("Reloading file");
+                    let _ = event_proxy.send_event(InlyneEvent::FileReload);
+                }
+                _ => {}
+            }
+        }
+    });
+}

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -78,27 +78,22 @@ fn endlessly_handle_messages<C: Callback>(
         .watch(&file_path, RecursiveMode::NonRecursive)
         .unwrap();
 
-    let poll_registering_watcher = |watcher: &mut RecommendedWatcher, file_path: &Path| {
-        let mut delay = Duration::from_millis(10);
+    let poll_registering_watcher = |watcher: &mut RecommendedWatcher, file_path: &Path| loop {
+        std::thread::sleep(Duration::from_millis(20));
 
-        loop {
-            std::thread::sleep(delay);
-            delay = Duration::from_millis(100);
-
-            let _ = watcher.unwatch(file_path);
-            if watcher
-                .watch(file_path, RecursiveMode::NonRecursive)
-                .is_ok()
-            {
-                break;
-            }
+        let _ = watcher.unwatch(file_path);
+        if watcher
+            .watch(file_path, RecursiveMode::NonRecursive)
+            .is_ok()
+        {
+            break;
         }
     };
 
     while let Ok(msg) = msg_rx.recv() {
         match msg {
             WatcherMsg::Notify(Ok(event)) => {
-                log::debug!("File event: {:#?}", event);
+                log::trace!("File event: {:#?}", event);
 
                 if matches!(
                     event.kind,

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -13,7 +13,7 @@ const LONG_TIMEOUT: Duration = Duration::from_millis(2_000);
 const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
 
 fn delay() {
-    std::thread::sleep(LONG_DELAY);
+    std::thread::sleep(DELAY);
 }
 
 fn touch(file: &Path) {

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -8,11 +8,11 @@ impl Callback for mpsc::Sender<()> {
     }
 }
 
-const LONG_DELAY: Duration = Duration::from_millis(200);
+const DELAY: Duration = Duration::from_millis(100);
 const LONG_TIMEOUT: Duration = Duration::from_millis(2_000);
 const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
 
-fn long_sleep() {
+fn delay() {
     std::thread::sleep(LONG_DELAY);
 }
 
@@ -54,7 +54,7 @@ fn the_gauntlet() {
     let watcher = Watcher::spawn_inner(callback_tx, main_file.clone());
 
     // Give the watcher time to get comfy :)
-    long_sleep();
+    delay();
 
     // Sanity check watching
     touch(&main_file);
@@ -73,7 +73,7 @@ fn the_gauntlet() {
     touch(&swapped_out_file);
     assert_no_message(&callback_rx);
     // The "slowly" part of this (give the watcher time to fail and start polling)
-    long_sleep();
+    delay();
     fs::rename(&swapped_in_file, &rel_file).unwrap();
     assert_at_least_one_message(&callback_rx);
     fs::remove_file(&swapped_out_file).unwrap();

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -1,0 +1,88 @@
+use std::{fs, path::Path, sync::mpsc, time::Duration};
+
+use super::{Callback, Watcher};
+
+impl Callback for mpsc::Sender<()> {
+    fn update(&self) {
+        self.send(()).unwrap();
+    }
+}
+
+const SHORT_DURATION: Duration = Duration::from_millis(50);
+const LONG_DURATION: Duration = Duration::from_millis(200);
+
+fn short_sleep() {
+    std::thread::sleep(SHORT_DURATION);
+}
+
+fn long_sleep() {
+    std::thread::sleep(LONG_DURATION);
+}
+
+fn touch(file: &Path) {
+    let now = filetime::FileTime::now();
+    filetime::set_file_mtime(file, now).unwrap();
+}
+
+macro_rules! assert_no_message {
+    ($callback:ident) => {
+        assert!($callback.recv_timeout(SHORT_DURATION).is_err());
+    };
+}
+
+macro_rules! assert_at_least_one_message {
+    ($callback:ident) => {
+        assert!($callback.recv_timeout(LONG_DURATION).is_ok());
+        while $callback.try_recv().is_ok() {}
+    };
+}
+
+// Unfortunately this needs to be littered with sleeps to work :/
+#[test]
+fn the_gauntlet() {
+    // Create our dummy test env
+    let temp_dir = tempfile::Builder::new()
+        .prefix("inlyne-tests-")
+        .tempdir()
+        .unwrap();
+    let base = temp_dir.path();
+    let main_file = base.join("main.md");
+    let rel_file = base.join("rel.md");
+    let swapped_in_file = base.join("swap_me_in.md");
+    let swapped_out_file = base.join("swap_out_to_me.md");
+    fs::write(&main_file, "# Main\n\n[rel](./rel.md)").unwrap();
+    fs::write(&rel_file, "# Rel").unwrap();
+    fs::write(&swapped_in_file, "# Swapped").unwrap();
+
+    // Setup our watcher
+    let (callback_tx, callback_rx) = mpsc::channel::<()>();
+    let watcher = Watcher::spawn_inner(callback_tx, main_file.clone());
+
+    // Give the watcher time to get comfy :)
+    short_sleep();
+
+    // Sanity check watching
+    touch(&main_file);
+    assert_at_least_one_message!(callback_rx);
+
+    // Updating a file follows the new file and not the old one
+    watcher.update_path(&rel_file);
+    assert_at_least_one_message!(callback_rx);
+    touch(&main_file);
+    assert_no_message!(callback_rx);
+    touch(&rel_file);
+    assert_at_least_one_message!(callback_rx);
+
+    // We can slowly swap out the file and it will only follow the file it's supposed to
+    fs::rename(&rel_file, &swapped_out_file).unwrap();
+    touch(&swapped_out_file);
+    assert_no_message!(callback_rx);
+    // The "slowly" part of this (give the watcher time to fail and start polling)
+    long_sleep();
+    fs::rename(&swapped_in_file, &rel_file).unwrap();
+    assert_at_least_one_message!(callback_rx);
+    fs::remove_file(&swapped_out_file).unwrap();
+    assert_no_message!(callback_rx);
+    touch(&rel_file);
+    assert_at_least_one_message!(callback_rx);
+}

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -8,8 +8,8 @@ impl Callback for mpsc::Sender<()> {
     }
 }
 
-const SHORT_DELAY: Duration = Duration::from_millis(10);
-const LONG_DELAY: Duration = Duration::from_millis(100);
+const SHORT_DELAY: Duration = Duration::from_millis(50);
+const LONG_DELAY: Duration = Duration::from_millis(200);
 
 fn long_sleep() {
     std::thread::sleep(LONG_DELAY);

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -10,7 +10,7 @@ impl Callback for mpsc::Sender<()> {
 
 const LONG_DELAY: Duration = Duration::from_millis(200);
 const LONG_TIMEOUT: Duration = Duration::from_millis(2_000);
-const SHORT_TIMEOUT: Duration = Duration::from_millis(20);
+const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
 
 fn long_sleep() {
     std::thread::sleep(LONG_DELAY);

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -8,8 +8,9 @@ impl Callback for mpsc::Sender<()> {
     }
 }
 
-const SHORT_DELAY: Duration = Duration::from_millis(50);
 const LONG_DELAY: Duration = Duration::from_millis(200);
+const LONG_TIMEOUT: Duration = Duration::from_millis(2_000);
+const SHORT_TIMEOUT: Duration = Duration::from_millis(20);
 
 fn long_sleep() {
     std::thread::sleep(LONG_DELAY);
@@ -22,16 +23,16 @@ fn touch(file: &Path) {
 
 #[track_caller]
 fn assert_no_message(callback: &mpsc::Receiver<()>) {
-    assert!(callback.recv_timeout(SHORT_DELAY).is_err());
+    assert!(callback.recv_timeout(SHORT_TIMEOUT).is_err());
 }
 
 #[track_caller]
 fn assert_at_least_one_message(callback: &mpsc::Receiver<()>) {
-    assert!(callback.recv_timeout(LONG_DELAY).is_ok());
-    while callback.recv_timeout(SHORT_DELAY).is_ok() {}
+    assert!(callback.recv_timeout(LONG_TIMEOUT).is_ok());
+    while callback.recv_timeout(SHORT_TIMEOUT).is_ok() {}
 }
 
-// Unfortunately this needs to be littered with sleeps to work :/
+// Unfortunately this needs to be littered with sleeps/timeouts to work right :/
 #[test]
 fn the_gauntlet() {
     // Create our dummy test env


### PR DESCRIPTION
Before file watching would keep watching a file even after it was renamed. File watching would also fail permanently if you did something like removing the original file and replacing with a new file after a short delay

These changes handle all of the above cases by `.unwratch()`ing the file after name changes (the path associated with the watcher is still the original path name even after a rename) and looping continuously to re-register the watcher after the original file is renamed/removed

I also added a reminder to fix watching the file after changing the file by clicking a markdown link from within the current file, but haven't handled that quite yet