### PR TITLE
Toggle on autolink extension

### DIFF
--- a/src/interpreter/snapshots/inlyne__interpreter__tests__bare_link_gets_autolinked.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__bare_link_gets_autolinked.snap
@@ -1,0 +1,56 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\nIn a paragraph https://example.org\n\n- In a list https://example.org\n\n\n --- html\n\n<p>In a paragraph <a href=\"https://example.org\">https://example.org</a></p>\n<ul>\n<li>In a list <a href=\"https://example.org\">https://example.org</a></li>\n</ul>\n"
+expression: interpret_md(text)
+---
+[
+    TextBox(
+        TextBox {
+            texts: [
+                Text {
+                    text: "In a paragraph ",
+                    default_color: Color(BLACK),
+                    ..
+                },
+                Text {
+                    text: "https://example.org",
+                    color: Some(Color { r: 0.09, g: 0.13, b: 1.00 }),
+                    link: Some("https://example.org"),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            texts: [
+                Text {
+                    text: "· ",
+                    default_color: Color(BLACK),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "In a list ",
+                    default_color: Color(BLACK),
+                    ..
+                },
+                Text {
+                    text: "https://example.org",
+                    color: Some(Color { r: 0.09, g: 0.13, b: 1.00 }),
+                    link: Some("https://example.org"),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -149,10 +149,17 @@ Fenced code block with no language tag
 fn main() {}
 ```";
 
+const BARE_LINK_GETS_AUTOLINKED: &str = "\
+In a paragraph https://example.org
+
+- In a list https://example.org
+";
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
     (code_block_bg_color, CODE_BLOCK_BG_COLOR),
+    (bare_link_gets_autolinked, BARE_LINK_GETS_AUTOLINKED),
 );
 
 /// Spin up a server, so we can test network requests without external services

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,6 +79,7 @@ impl From<CursorIcon> for HoverInfo {
 
 pub fn markdown_to_html(md: &str, syntax_theme: SyntectTheme) -> String {
     let mut options = ComrakOptions::default();
+    options.extension.autolink = true;
     options.extension.table = true;
     options.extension.strikethrough = true;
     options.extension.tasklist = true;


### PR DESCRIPTION
Toggles on the autolink extension and makes sure that things work fine in the places we would normally expect to see it

This extension matches GitHub's behavior, so people probably expect it to work OOTB