### PR TITLE
Improve syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,6 +1765,7 @@ dependencies = [
  "tempfile",
  "tiny-skia",
  "toml",
+ "two-face",
  "twox-hash",
  "usvg",
  "wgpu",
@@ -3931,6 +3932,16 @@ name = "ttf-parser"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44dcf002ae3b32cd25400d6df128c5babec3927cd1eb7ce813cfff20eb6c3746"
+
+[[package]]
+name = "two-face"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655eebf0a106a5b97728bfdc108e76a7f36f069625b328ddf02627ce3d5e9452"
+dependencies = [
+ "serde",
+ "syntect",
+]
 
 [[package]]
 name = "twox-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,11 @@ twox-hash = "1.6.3"
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d338f3731da519d182bbc074de46382984ab7c4a" }
 syntect = "5.0.0"
 
+[dependencies.two-face]
+version = "0.1.1"
+default-features = false
+features = ["extra-syntax"]
+
 [dependencies.glyphon]
 version = "0.2"
 git = "https://github.com/trimental/glyphon"

--- a/src/color.rs
+++ b/src/color.rs
@@ -107,6 +107,9 @@ impl PartialEq for Theme {
     }
 }
 
+// TODO: the error message here degraded when switching this to allow for custom themes. It'd be
+//       good to still list all the default themes when passing in something else. Add a test for
+//       the error message
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum SyntaxTheme {

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__handles_comma_in_info_str.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__handles_comma_in_info_str.snap
@@ -1,0 +1,30 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n```rust,ignore\nlet v = 1;\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust,ignore\"><span style=\"color:#323232;\">let v = 1;\n</span></code></pre>\n"
+expression: interpret_md(text)
+---
+[
+    TextBox(
+        TextBox {
+            background_color: Some(Color { r: 0.92, g: 0.94, b: 0.96 }),
+            is_code_block: true,
+            texts: [
+                Text {
+                    text: "let v = 1;",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.03, g: 0.03, b: 0.03 }),
+                    ..
+                },
+                Text {
+                    text: "\n",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__handles_comma_in_info_str.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__handles_comma_in_info_str.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: " --- md\n\n```rust,ignore\nlet v = 1;\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust,ignore\"><span style=\"color:#323232;\">let v = 1;\n</span></code></pre>\n"
+description: " --- md\n\n```rust,ignore\nlet v = 1;\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust,ignore\"><span style=\"font-weight:bold;color:#a71d5d;\">let</span><span style=\"color:#323232;\"> v </span><span style=\"font-weight:bold;color:#a71d5d;\">= </span><span style=\"color:#0086b3;\">1</span><span style=\"color:#323232;\">;\n</span></code></pre>\n"
 expression: interpret_md(text)
 ---
 [
@@ -10,7 +10,33 @@ expression: interpret_md(text)
             is_code_block: true,
             texts: [
                 Text {
-                    text: "let v = 1;",
+                    text: "let",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: " v ",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.03, g: 0.03, b: 0.03 }),
+                    ..
+                },
+                Text {
+                    text: "= ",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "1",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.00, g: 0.24, b: 0.45 }),
+                    ..
+                },
+                Text {
+                    text: ";",
                     font_family: Monospace,
                     color: Some(Color { r: 0.03, g: 0.03, b: 0.03 }),
                     ..

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__toml_gets_highlighted.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__toml_gets_highlighted.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: " --- md\n\n```toml\nkey = 123\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-toml\"><span style=\"color:#323232;\">key = 123\n</span></code></pre>\n"
+description: " --- md\n\n```toml\nkey = 123\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-toml\"><span style=\"color:#63a35c;\">key </span><span style=\"color:#323232;\">= </span><span style=\"color:#0086b3;\">123\n</span></code></pre>\n"
 expression: interpret_md(text)
 ---
 [
@@ -10,9 +10,21 @@ expression: interpret_md(text)
             is_code_block: true,
             texts: [
                 Text {
-                    text: "key = 123",
+                    text: "key ",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.12, g: 0.37, b: 0.11 }),
+                    ..
+                },
+                Text {
+                    text: "= ",
                     font_family: Monospace,
                     color: Some(Color { r: 0.03, g: 0.03, b: 0.03 }),
+                    ..
+                },
+                Text {
+                    text: "123",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.00, g: 0.24, b: 0.45 }),
                     ..
                 },
                 Text {

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__toml_gets_highlighted.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__toml_gets_highlighted.snap
@@ -1,0 +1,30 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n```toml\nkey = 123\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-toml\"><span style=\"color:#323232;\">key = 123\n</span></code></pre>\n"
+expression: interpret_md(text)
+---
+[
+    TextBox(
+        TextBox {
+            background_color: Some(Color { r: 0.92, g: 0.94, b: 0.96 }),
+            is_code_block: true,
+            texts: [
+                Text {
+                    text: "key = 123",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.03, g: 0.03, b: 0.03 }),
+                    ..
+                },
+                Text {
+                    text: "\n",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -155,11 +155,18 @@ In a paragraph https://example.org
 - In a list https://example.org
 ";
 
+const TOML_GETS_HIGHLIGHTED: &str = "\
+```toml
+key = 123
+```
+";
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
     (code_block_bg_color, CODE_BLOCK_BG_COLOR),
     (bare_link_gets_autolinked, BARE_LINK_GETS_AUTOLINKED),
+    (toml_gets_highlighted, TOML_GETS_HIGHLIGHTED),
 );
 
 /// Spin up a server, so we can test network requests without external services

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -161,12 +161,19 @@ key = 123
 ```
 ";
 
+const HANDLES_COMMA_IN_INFO_STR: &str = "\
+```rust,ignore
+let v = 1;
+```
+";
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
     (code_block_bg_color, CODE_BLOCK_BG_COLOR),
     (bare_link_gets_autolinked, BARE_LINK_GETS_AUTOLINKED),
     (toml_gets_highlighted, TOML_GETS_HIGHLIGHTED),
+    (handles_comma_in_info_str, HANDLES_COMMA_IN_INFO_STR),
 );
 
 /// Spin up a server, so we can test network requests without external services

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -95,9 +95,10 @@ pub fn markdown_to_html(md: &str, syntax_theme: SyntectTheme) -> String {
     theme_set
         .themes
         .insert(String::from(dummy_name), syntax_theme);
+    let syn_set = two_face::syntax::extra();
     let adapter = SyntectAdapterBuilder::new()
+        .syntax_set(syn_set)
         .theme_set(theme_set)
-        // .theme(syntax_theme.as_syntect_name())
         .theme(dummy_name)
         .build();
 


### PR DESCRIPTION
This fixes a couple of issues that both conveniently manifest in `reqwest`'s README

1. The default syntax definitions are missing a lot of common languages (including TOML)
2. Fenced code blocks may have an info string like ```` ```rust,ignore```` since some projects use the README for doc stuff. `comrak` doesn't recognized this as a Rust block although GitHub does

## `main`

![image](https://github.com/trimental/inlyne/assets/30302768/4a60d42c-3efc-4c05-898a-aecd223fb66a)


## This PR

![image](https://github.com/trimental/inlyne/assets/30302768/fb86b7cd-62dd-4c95-a3d4-4f8d6091552f)

Yes the Rust highlighting is this basic for this example. It turns out that syntect is stuck using several year old syntax definitions for a lot of languages since Sublime Text has made changes to syntax definitions that would require significant changes to syntect

Part of this is also from the default dark theme. `two-face` is now getting pulled in which includes a lot more themes though, so I'll add those in a future PR