### PR TITLE
Make config code highlighter error more friendly

### DIFF
--- a/src/opts/tests/error_msg.rs
+++ b/src/opts/tests/error_msg.rs
@@ -1,0 +1,20 @@
+macro_rules! snapshot_config_parse_error {
+    ( $( ($test_name:ident, $md_text:ident) ),* $(,)? ) => {
+        $(
+            #[test]
+            fn $test_name() {
+                let err = ::toml::from_str::<$crate::opts::Config>($md_text).unwrap_err();
+
+                ::insta::with_settings!({
+                    description => $md_text,
+                }, {
+                    ::insta::assert_display_snapshot!(err);
+                });
+            }
+        )*
+    }
+}
+
+const UNKNOWN_THEME: &str = r#"light-theme.code-highlighter = "doesnt-exist""#;
+
+snapshot_config_parse_error!((unknown_theme, UNKNOWN_THEME));

--- a/src/opts/tests/error_msg.rs
+++ b/src/opts/tests/error_msg.rs
@@ -16,5 +16,9 @@ macro_rules! snapshot_config_parse_error {
 }
 
 const UNKNOWN_THEME: &str = r#"light-theme.code-highlighter = "doesnt-exist""#;
+const INVALID_THEME_TY: &str = "light-theme.code-highlighter = []";
 
-snapshot_config_parse_error!((unknown_theme, UNKNOWN_THEME));
+snapshot_config_parse_error!(
+    (unknown_theme, UNKNOWN_THEME),
+    (invalid_theme_ty, INVALID_THEME_TY),
+);

--- a/src/opts/tests/mod.rs
+++ b/src/opts/tests/mod.rs
@@ -1,0 +1,1 @@
+mod parse;

--- a/src/opts/tests/mod.rs
+++ b/src/opts/tests/mod.rs
@@ -1,1 +1,2 @@
+mod error_msg;
 mod parse;

--- a/src/opts/tests/parse.rs
+++ b/src/opts/tests/parse.rs
@@ -1,10 +1,12 @@
 use std::{ffi::OsString, path::PathBuf};
 
-use super::{cli, config, Opts, ResolvedTheme, ThemeType};
 use crate::color::{SyntaxTheme, Theme, ThemeDefaults};
 use crate::keybindings::Keybindings;
-use crate::opts::config::{FontOptions, LinesToScroll};
-use crate::opts::Args;
+use crate::opts::{
+    cli,
+    config::{self, FontOptions, LinesToScroll},
+    Args, Opts, ResolvedTheme, ThemeType,
+};
 
 use pretty_assertions::assert_eq;
 

--- a/src/opts/tests/parse.rs
+++ b/src/opts/tests/parse.rs
@@ -202,7 +202,7 @@ fn custom_syntax_theme() {
     fn config_with_theme_at(path: PathBuf) -> config::Config {
         let mut config = config::Config::default();
         config.light_theme = Some(config::OptionalTheme {
-            code_highlighter: Some(SyntaxTheme::Custom { path }),
+            code_highlighter: Some(SyntaxTheme::custom(path)),
             ..Default::default()
         });
         config

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__invalid_theme_ty.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__invalid_theme_ty.snap
@@ -1,0 +1,13 @@
+---
+source: src/opts/tests/error_msg.rs
+description: "light-theme.code-highlighter = []"
+expression: err
+---
+TOML parse error at line 1, column 32
+  |
+1 | light-theme.code-highlighter = []
+  |                                ^^
+Expects either a default theme name or a path to a custom theme. E.g.
+default: "inspired-github"
+custom:  { path = "/path/to/custom.tmTheme" }
+

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__unknown_theme.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__unknown_theme.snap
@@ -1,0 +1,11 @@
+---
+source: src/opts/tests/error_msg.rs
+description: "light-theme.code-highlighter = \"doesnt-exist\""
+expression: err
+---
+TOML parse error at line 1, column 32
+  |
+1 | light-theme.code-highlighter = "doesnt-exist"
+  |                                ^^^^^^^^^^^^^^
+data did not match any variant of untagged enum SyntaxTheme
+

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__unknown_theme.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__unknown_theme.snap
@@ -7,5 +7,5 @@ TOML parse error at line 1, column 32
   |
 1 | light-theme.code-highlighter = "doesnt-exist"
   |                                ^^^^^^^^^^^^^^
-data did not match any variant of untagged enum SyntaxTheme
+"doesnt-exist" didn't match any of the expected variants: ["base16-ocean-dark", "base16-eighties-dark", "base16-mocha-dark", "base16-ocean-light", "inspired-github", "solarized-dark", "solarized-light"]
 


### PR DESCRIPTION
Unfortunately switching the theme to `#[serde(untagged)]` makes the error message much worse. This fixes things back up to be nice and friendly again :)