### PR TITLE
More succinct debug impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,6 +1760,7 @@ dependencies = [
  "resvg",
  "serde",
  "serde_yaml",
+ "smart-debug",
  "syntect",
  "taffy",
  "tempfile",
@@ -3471,6 +3472,17 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "smart-debug"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91dddcfd8ca778ef2f1d2b57dfccaa12b8d4e8f715c99211c62802838446f14e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
 
 [[package]]
 name = "smithay-client-toolkit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ fxhash = "0.2.1"
 twox-hash = "1.6.3"
 taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d338f3731da519d182bbc074de46382984ab7c4a" }
 syntect = "5.0.0"
+smart-debug = "0.0.1"
 
 [dependencies.two-face]
 version = "0.1.1"

--- a/src/text.rs
+++ b/src/text.rs
@@ -6,13 +6,14 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::debug_impls;
+use crate::debug_impls::{self, DebugInline, DebugInlineMaybeF32Color};
 
 use fxhash::{FxHashMap, FxHashSet};
 use glyphon::{
     Affinity, Attrs, AttrsList, BufferLine, Color, Cursor, FamilyOwned, FontSystem, Style,
     SwashCache, TextArea, TextBounds, Weight,
 };
+use smart_debug::SmartDebug;
 use taffy::{
     prelude::{AvailableSpace, Size as TaffySize},
     tree::Measurable,
@@ -58,25 +59,26 @@ impl Measurable for TextBoxMeasure {
     }
 }
 
-#[derive(Clone)]
+#[derive(SmartDebug, Clone)]
+#[debug(ignore_defaults)]
 pub struct TextBox {
-    pub indent: f32,
     pub font_size: f32,
-    pub texts: Vec<Text>,
-    pub is_code_block: bool,
-    pub is_quote_block: Option<usize>,
-    pub is_checkbox: Option<bool>,
-    pub is_anchor: Option<String>,
     pub align: Align,
-    pub hidpi_scale: f32,
+    pub indent: f32,
     pub padding_height: f32,
+    #[debug(wrapper = DebugInlineMaybeF32Color)]
     pub background_color: Option<[f32; 4]>,
-}
-
-impl fmt::Debug for TextBox {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        debug_impls::text_box(self, f)
-    }
+    pub is_code_block: bool,
+    #[debug(wrapper = DebugInline)]
+    pub is_quote_block: Option<usize>,
+    #[debug(wrapper = DebugInline)]
+    pub is_checkbox: Option<bool>,
+    #[debug(wrapper = DebugInline)]
+    pub is_anchor: Option<String>,
+    #[debug(no_ignore)]
+    pub texts: Vec<Text>,
+    #[debug(ignore)]
+    pub hidpi_scale: f32,
 }
 
 impl Default for TextBox {


### PR DESCRIPTION
I'm dogfooding a new crate I released primarily for the purpose of making debug impls easier to implement for things like snapshot tests. The only custom one I wasn't able to get rid of was from `Text` due to the custom formatting that merges all of the styles