### PR TITLE
fix: add missing `fontdb` feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,6 +1231,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237ff9f0813bbfc9de836016472e0c9ae7802f174a51594607e5f4ff334cb2f5"
 dependencies = [
+ "fontconfig-parser",
  "log",
  "memmap2 0.5.10",
  "slotmap",
@@ -1847,6 +1848,7 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger",
  "filetime",
+ "fontdb 0.13.1",
  "fxhash",
  "glyphon",
  "html-escape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ syntect = "5.1.0"
 smart-debug = "0.0.3"
 two-face = "0.3.0"
 
+# Required for WGPU to work properly with Vulkan
+fontdb = { version = "0.13.1", features = ["fontconfig"] }
+
 [dependencies.glyphon]
 version = "0.2"
 git = "https://github.com/trimental/glyphon"


### PR DESCRIPTION
This solves an issue with the NixOS build where fonts are required at
runtime for inlyne to start. With the `fontconfig` feature flag inlyne
will use font-config to determine a font.

Partially resolves #164
