### PR TITLE
Add relevant keywords to `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
     "/.github/*",
     "/tests/manual_test_data/*",
 ]
+keywords = ["markdown", "viewer", "gpu"]
 
 [features]
 default = ["x11"]


### PR DESCRIPTION
Should help `inlyne` appear higher in searches on [crates.io](https://crates.io) and [lib.rs](https://lib.rs)