### PR TITLE
Add tests for elements nested in a list item

### DIFF
--- a/src/interpreter/snapshots/inlyne__interpreter__tests__code_in_ordered_list.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__code_in_ordered_list.snap
@@ -1,0 +1,92 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n1. 1st item\n\n    ```rust\n    fn main() {}\n    ```\n\n2. 2nd item\n\n\n --- html\n\n<ol>\n<li>\n<p>1st item</p>\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust\"><span style=\"font-weight:bold;color:#a71d5d;\">fn </span><span style=\"font-weight:bold;color:#795da3;\">main</span><span style=\"color:#323232;\">() {}\n</span></code></pre>\n</li>\n<li>\n<p>2nd item</p>\n</li>\n</ol>\n"
+expression: interpret_md(text)
+---
+[
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            texts: [
+                Text {
+                    text: "1. ",
+                    default_color: Color(BLACK),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "1st item",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            background_color: Some(Color { r: 0.92, g: 0.94, b: 0.96 }),
+            is_code_block: true,
+            texts: [
+                Text {
+                    text: "fn ",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "main",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.19, g: 0.11, b: 0.37 }),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "() {}",
+                    font_family: Monospace,
+                    color: Some(Color { r: 0.03, g: 0.03, b: 0.03 }),
+                    ..
+                },
+                Text {
+                    text: "\n",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            texts: [
+                Text {
+                    text: "2. ",
+                    default_color: Color(BLACK),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "2nd item",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__para_in_ordered_list.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__para_in_ordered_list.snap
@@ -1,0 +1,70 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n1. 1st item\n\n    Nested paragraph\n\n2. 2nd item\n\n\n --- html\n\n<ol>\n<li>\n<p>1st item</p>\n<p>Nested paragraph</p>\n</li>\n<li>\n<p>2nd item</p>\n</li>\n</ol>\n"
+expression: interpret_md(text)
+---
+[
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            texts: [
+                Text {
+                    text: "1. ",
+                    default_color: Color(BLACK),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "1st item",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            texts: [
+                Text {
+                    text: "Nested paragraph",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            indent: 50.0,
+            texts: [
+                Text {
+                    text: "2. ",
+                    default_color: Color(BLACK),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "2nd item",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -185,6 +185,24 @@ const ORDERED_LIST_IN_UNORDERED: &str = "\
 - bullet
 ";
 
+const PARA_IN_ORDERED_LIST: &str = "\
+1. 1st item
+
+    Nested paragraph
+
+2. 2nd item
+";
+
+const CODE_IN_ORDERED_LIST: &str = "\
+1. 1st item
+
+    ```rust
+    fn main() {}
+    ```
+
+2. 2nd item
+";
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
@@ -195,6 +213,8 @@ snapshot_interpreted_elements!(
     (unordered_list_in_ordered, UNORDERED_LIST_IN_ORDERED),
     (nested_ordered_list, NESTED_ORDERED_LIST),
     (ordered_list_in_unordered, ORDERED_LIST_IN_UNORDERED),
+    (para_in_ordered_list, PARA_IN_ORDERED_LIST),
+    (code_in_ordered_list, CODE_IN_ORDERED_LIST),
 );
 
 /// Spin up a server, so we can test network requests without external services


### PR DESCRIPTION
Just adds tests to cover the case described in #174. This will be accompanied by a backport to fix this behavior on the v0.3 release series in the next few days

Notably also worth mentioning that this behavior isn't entirely correct since the element nested within the list item should be indented further to indicate that it is part of the list item. I opened #175 to talk about how the interpreter can be refactored to better handle this kind of stuff in the future