### PR TITLE
Correctly set the version for windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,9 @@ jobs:
       run: |
         ci/ubuntu-install-packages
 
-
     - name: Set the version
       id: version
+      shell: bash
       run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
     - name: Install Rust


### PR DESCRIPTION
Release CI is a fickle beast...

Windows is the only release platform that defaults to a shell other than bash. The step for setting the version was changed with bash in mind which caused it to fail on windows. This caused the artifact name to have an empty space instead of the version

The fix is to simply use bash on all platforms