### PR TITLE
Downgrade `wgpu-core` to fix panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2131,6 +2131,7 @@ dependencies = [
  "two-face",
  "usvg",
  "wgpu",
+ "wgpu-core",
  "wgpu_glyph",
  "winit",
  "wiremock",
@@ -5028,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8a44dd301a30ceeed3c27d8c0090433d3da04d7b2a4042738095a424d12ae7"
+checksum = "ecf7454d9386f602f7399225c92dd2fbdcde52c519bc8fb0bd6fbeb388075dc2"
 dependencies = [
  "arrayvec",
  "bit-vec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,13 @@ keywords = ["markdown", "viewer", "gpu"]
 [dependencies]
 wgpu_glyph =  "0.21"
 winit = "0.28.7"
-wgpu = "0.17"
+# HACK: Pinning to the exact version `=` here because 0.17.1 introduced a bug
+# that can be a frequent source of panics. We can't go above 0.17.x because we
+# share a `wgpu` dependency with `wgpu_glyph` who is unlikely to be updated now
+# that text rendering with `cosmic-text` is a thing. This won't be a problem in
+# `inlyne` v0.4, so this is only temporary anyways
+wgpu-core = "=0.17.0"
+wgpu = "0.17.0"
 bytemuck = "1.14.0"
 lyon = "1.0.1"
 comrak = { version = "0.19.0", default-features = false, features = ["syntect"] }


### PR DESCRIPTION
Fixes #177

Updating dependencies in the v0.3.2 update introduced a panic that can occur with relative ease in `wgpu-core`. The simplest fix is just to pin `wgpu-core` to the version before the panic was introduced. This is only needed for `inlyne` v0.3.x since v0.4 can actually update to newer `wgpu` versions