### PR TITLE
Setup logging for tests

### DIFF
--- a/src/image/tests.rs
+++ b/src/image/tests.rs
@@ -1,6 +1,7 @@
 use std::{fmt, fs, path::Path};
 
 use super::ImageData;
+use crate::test_utils::init_test_log;
 
 // Checks that the image crate converting to RGBA8 is the same as our technique
 fn check(input_path: &Path) {
@@ -24,6 +25,8 @@ fn check(input_path: &Path) {
 
 #[test]
 fn source_image_variety() {
+    init_test_log();
+
     for file in [
         "rgb8.gif",
         "rgb8.jpg",

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -11,14 +11,13 @@ use std::{
 };
 
 use super::{HtmlInterpreter, ImageCallback, WindowInteractor};
-use crate::{color::Theme, image::ImageData, Element, ImageCache};
+use crate::{color::Theme, image::ImageData, test_utils::init_test_log, Element, ImageCache};
 
 use wgpu::TextureFormat;
 use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
 // We use a dummy window with an internal counter that keeps track of when rendering a single md
 // document is finished
-#[derive(Default)]
 struct AtomicCounter(Arc<AtomicU32>);
 
 impl Clone for AtomicCounter {
@@ -113,6 +112,8 @@ macro_rules! snapshot_interpreted_elements {
         $(
             #[test]
             fn $test_name() {
+                $crate::test_utils::init_test_log();
+
                 let text = $md_text;
 
                 let syntect_theme = $crate::color::Theme::light_default().code_highlighter;
@@ -237,6 +238,8 @@ fn mock_file_server(url_path: &str, mime: &str, file_path: &Path) -> (MockServer
 
 #[test]
 fn centered_image_with_size_align_and_link() {
+    init_test_log();
+
     let logo_path = Path::new("tests").join("assets").join("bun_logo.png");
     let (_server, logo_url) = mock_file_server("/bun_logo.png", "image/png", &logo_path);
 

--- a/src/keybindings/tests.rs
+++ b/src/keybindings/tests.rs
@@ -2,12 +2,15 @@ use super::{
     action::{Action, VertDirection},
     Key, KeyCombo, KeyCombos, Keybindings, ModifiedKey,
 };
+use crate::test_utils::init_test_log;
 
 use serde::Deserialize;
 use winit::event::{ModifiersState, VirtualKeyCode};
 
 #[test]
 fn sanity() {
+    init_test_log();
+
     #[derive(Deserialize, Debug)]
     struct Holder {
         inner: Vec<(Action, KeyCombo)>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ pub mod opts;
 pub mod positioner;
 pub mod renderer;
 pub mod table;
+pub mod test_utils;
 pub mod text;
 pub mod utils;
 mod watcher;

--- a/src/opts/tests/error_msg.rs
+++ b/src/opts/tests/error_msg.rs
@@ -3,6 +3,8 @@ macro_rules! snapshot_config_parse_error {
         $(
             #[test]
             fn $test_name() {
+                $crate::test_utils::init_test_log();
+
                 let err = ::toml::from_str::<$crate::opts::Config>($md_text).unwrap_err();
 
                 ::insta::with_settings!({

--- a/src/opts/tests/parse.rs
+++ b/src/opts/tests/parse.rs
@@ -7,6 +7,7 @@ use crate::opts::{
     config::{self, FontOptions, LinesToScroll},
     Args, Opts, ResolvedTheme, ThemeType,
 };
+use crate::test_utils::init_test_log;
 
 use pretty_assertions::assert_eq;
 
@@ -42,11 +43,15 @@ impl ResolvedTheme {
 
 #[test]
 fn debug_assert() {
+    init_test_log();
+
     cli::command().debug_assert();
 }
 
 #[test]
 fn defaults() {
+    init_test_log();
+
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
             Args::try_parse_from(gen_args(vec!["file.md"])).unwrap(),
@@ -60,6 +65,8 @@ fn defaults() {
 
 #[test]
 fn config_overrides_default() {
+    init_test_log();
+
     // Light system theme with dark in config
     let config = config::Config {
         theme: Some(ThemeType::Dark),
@@ -116,6 +123,8 @@ fn config_overrides_default() {
 
 #[test]
 fn from_cli() {
+    init_test_log();
+
     assert_eq!(
         Opts::parse_and_load_with_system_theme(
             Args::try_parse_from(gen_args(vec!["--theme", "dark", "file.md"])).unwrap(),
@@ -152,6 +161,8 @@ fn from_cli() {
 
 #[test]
 fn cli_kitchen_sink() {
+    init_test_log();
+
     #[rustfmt::skip]
     let args = gen_args(vec![
         "--theme", "dark",
@@ -178,6 +189,8 @@ fn cli_kitchen_sink() {
 
 #[test]
 fn builtin_syntax_theme() {
+    init_test_log();
+
     let mut config = config::Config::default();
     config.light_theme = Some(config::OptionalTheme {
         code_highlighter: Some(SyntaxTheme::Defaults(ThemeDefaults::SolarizedLight)),
@@ -199,6 +212,8 @@ fn builtin_syntax_theme() {
 
 #[test]
 fn custom_syntax_theme() {
+    init_test_log();
+
     fn config_with_theme_at(path: PathBuf) -> config::Config {
         let mut config = config::Config::default();
         config.light_theme = Some(config::OptionalTheme {
@@ -236,6 +251,8 @@ fn custom_syntax_theme() {
 
 #[test]
 fn missing_file_arg() {
+    init_test_log();
+
     // A file arg should be required
     assert!(Args::try_parse_from(gen_args(Vec::new())).is_err());
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,10 @@
+use log::LevelFilter;
+
+pub fn init_test_log() {
+    // Ignore errors because other tests in the same binary may have already initialized the logger
+    let _ = env_logger::Builder::new()
+        .filter(Some("inlyne"), LevelFilter::Debug)
+        .filter(None, LevelFilter::Warn)
+        .is_test(true)
+        .try_init();
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,9 +242,12 @@ impl Cell {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::init_test_log;
 
     #[test]
     fn md_to_html() {
+        init_test_log();
+
         let text = "\
 ---
 title: Title

--- a/src/watcher/tests.rs
+++ b/src/watcher/tests.rs
@@ -1,6 +1,7 @@
 use std::{fs, path::Path, sync::mpsc, time::Duration};
 
 use super::{Callback, Watcher};
+use crate::test_utils::init_test_log;
 
 impl Callback for mpsc::Sender<()> {
     fn file_reload(&self) {
@@ -57,6 +58,8 @@ impl Delays {
 
 #[test]
 fn the_gauntlet() {
+    init_test_log();
+
     // This test can be flaky, so give it a few chances to succeed
     let mut last_panic = None;
     let mut delays = Delays::new();


### PR DESCRIPTION
Not much more than the title says. A little bit of boilerplate, but it sets things up so that logs get captured and emitted when tests fail which is nice for debugging