### PR TITLE
Fix README demo image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,11 +29,15 @@ _If you're wondering 'Is this relevant to me?' Then the answer is probably no
 
 - [ ] Check for unused dependencies
   - `$ cargo +nightly udeps`
+- [ ] Bump `version` in `Cargo.toml`
+- [ ] Propogate the change to `Cargo.lock`
+  - `$ cargo check -p inlyne`
+- [ ] Optional: If making a breaking release update the `example.png` link in
+  the README to point to the appropriate release branch
 - [ ] Update static assets
   - `$ cargo xtask gen`
 - [ ] Update `rust-version` in `Cargo.toml`
   - `$ cargo msrv --min 1.60 -- cargo check`
-- [ ] Bump `version` in `Cargo.toml`
 - [ ] Merge changes through a PR or directly to make sure CI passes
 - [ ] Publish on crates.io
   - `$ cargo publish`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ inlyne README.md --theme dark/light
 ```
 
 <p align="center">
-<img src="assets/img/example.png" width="800"/>
+<img src="https://raw.githubusercontent.com/trimental/inlyne/main/assets/img/example.png" width="800"/>
 </p>
 
 ## About

--- a/example.png
+++ b/example.png
@@ -1,0 +1,1 @@
+assets/img/example.png


### PR DESCRIPTION
In #187 I collected the various assets that were scattered around the repo, but in doing so I broke historic versions of the example.png in our README (like the currently published version on crates.io) since they were still pointing to the now non-existent image on `main`

This fixes that by adding a symlink to the old location that can be removed after v0.4 is published and can use a more stable image link. I've added a step to the release checklist to give us another reminder in the future