### PR TITLE
Switch CI cache to `Swatinem/rust-cache`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,11 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cargo build cache
-        uses: actions/cache@v3
-        with:
-          path: target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Stable
         run: cargo test --workspace
@@ -32,11 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cargo build cache
-        uses: actions/cache@v3
-        with:
-          path: target/
-          key: macos-arm-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install target
         run: rustup update && rustup target add aarch64-apple-darwin


### PR DESCRIPTION
`Swatinem/rust-cache` is better than our existing solutions in a few ways, but one of the problems it solves is that our existing cache keys do not take the compiler version into account, so a Rust update can leave us restoring a stale cache :(. That appears to be the cause behind some jobs rebuilding everything despite a full cache hit