### PR TITLE
Pretty up `KeyCombos` representation in user-facing errors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,8 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-C debuginfo=0"
 
+# TODO: build/test on stable and beta?
+
 jobs:
   build:
     strategy:
@@ -29,6 +31,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      # FIXME: This is in the wrong area. It should be below setting up the
+      # toolchain
       - name: Cache
         uses: Swatinem/rust-cache@v2
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -624,6 +624,7 @@ impl TokenSink for HtmlInterpreter {
 
                             self.push_current_textbox();
                         }
+                        // FIXME: `input` is self closing. This never gets called
                         "input" => {
                             self.push_current_textbox();
                             self.state.element_stack.pop();

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -85,13 +85,18 @@ pub struct Config {
 }
 
 impl Config {
+    pub fn load_from_str(s: &str) -> anyhow::Result<Self> {
+        let config = toml::from_str(s)?;
+        Ok(config)
+    }
+
     pub fn load_from_file(path: &Path) -> anyhow::Result<Self> {
         let config_content = read_to_string(path).context(format!(
             "Failed to read configuration file at '{}'",
             path.display()
         ))?;
 
-        Ok(toml::from_str(&config_content)?)
+        Self::load_from_str(&config_content)
     }
 
     pub fn load_from_system() -> anyhow::Result<Self> {

--- a/src/opts/tests/error_msg.rs
+++ b/src/opts/tests/error_msg.rs
@@ -1,14 +1,16 @@
+use crate::{keybindings::KeyCombos, opts::Config};
+
 macro_rules! snapshot_config_parse_error {
-    ( $( ($test_name:ident, $md_text:ident) ),* $(,)? ) => {
+    ( $( ($test_name:ident, $config_text:ident) ),* $(,)? ) => {
         $(
             #[test]
             fn $test_name() {
                 $crate::test_utils::init_test_log();
 
-                let err = ::toml::from_str::<$crate::opts::Config>($md_text).unwrap_err();
+                let err = $crate::opts::Config::load_from_str($config_text).unwrap_err();
 
                 ::insta::with_settings!({
-                    description => $md_text,
+                    description => $config_text,
                 }, {
                     ::insta::assert_display_snapshot!(err);
                 });
@@ -20,7 +22,65 @@ macro_rules! snapshot_config_parse_error {
 const UNKNOWN_THEME: &str = r#"light-theme.code-highlighter = "doesnt-exist""#;
 const INVALID_THEME_TY: &str = "light-theme.code-highlighter = []";
 
+const FIX_THIS_SUCKY_ERROR_MESSAGE: &str = r#"
+[keybindings]
+base = [
+    ["ToBottom", { key = " ", mod = ["Ctrl", "shift"] }],
+    ["ZoomOut", [{ key = " ", mod = ["ctrl", "shift"] }, "Enter"]],
+]
+"#;
+
 snapshot_config_parse_error!(
     (unknown_theme, UNKNOWN_THEME),
     (invalid_theme_ty, INVALID_THEME_TY),
+    // FIXME: vv
+    (fix_this_sucky_error_message, FIX_THIS_SUCKY_ERROR_MESSAGE),
+);
+
+fn keycombo_conflict_from_config(s: &str) -> anyhow::Result<anyhow::Error> {
+    let Config { keybindings, .. } = Config::load_from_str(s)?;
+    let mut combined_keybindings = keybindings.base.unwrap_or_default();
+    combined_keybindings.extend(keybindings.extra.unwrap_or_default());
+    let err = KeyCombos::new(combined_keybindings).unwrap_err();
+    Ok(err)
+}
+
+macro_rules! snapshot_keycombo_conflict_err {
+    ( $( ($test_name:ident, $config_text:ident) ),* $(,)? ) => {
+        $(
+            #[test]
+            fn $test_name() {
+                $crate::test_utils::init_test_log();
+
+                let err = keycombo_conflict_from_config($config_text).unwrap();
+
+                ::insta::with_settings!({
+                    description => $config_text,
+                }, {
+                    ::insta::assert_display_snapshot!(err);
+                });
+            }
+        )*
+    }
+}
+
+const BASIC_EQUALITY: &str = r#"
+[keybindings]
+base = [
+    ["ToTop", "a"],
+    ["ZoomReset", "a"],
+]
+"#;
+
+const SPECIAL_PREFIX: &str = r#"
+[keybindings]
+base = [
+    ["ToBottom", { key = "Space", mod = ["Ctrl", "Shift"] }],
+    ["ZoomOut", [{ key = "Space", mod = ["Ctrl", "Shift"] }, "Enter", 39]],
+]
+"#;
+
+snapshot_keycombo_conflict_err!(
+    (basic_equality, BASIC_EQUALITY),
+    (special_prefix, SPECIAL_PREFIX),
 );

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__basic_equality.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__basic_equality.snap
@@ -1,0 +1,8 @@
+---
+source: src/opts/tests/error_msg.rs
+description: "\n[keybindings]\nbase = [\n    [\"ToTop\", \"a\"],\n    [\"ZoomReset\", \"a\"],\n]\n"
+expression: err
+---
+A keycombo starts with another keycombo making it unreachable
+	Combo: a
+	Prefix: a

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__fix_this_sucky_error_message.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__fix_this_sucky_error_message.snap
@@ -1,0 +1,11 @@
+---
+source: src/opts/tests/error_msg.rs
+description: "\n[keybindings]\nbase = [\n    [\"ToBottom\", { key = \" \", mod = [\"Ctrl\", \"shift\"] }],\n    [\"ZoomOut\", [{ key = \" \", mod = [\"ctrl\", \"shift\"] }, \"Enter\"]],\n]\n"
+expression: err
+---
+TOML parse error at line 4, column 5
+  |
+4 |     ["ToBottom", { key = " ", mod = ["Ctrl", "shift"] }],
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+data did not match any variant of untagged enum ModifiedKeyOrModifiedKeys
+

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__special_prefix.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__special_prefix.snap
@@ -1,0 +1,8 @@
+---
+source: src/opts/tests/error_msg.rs
+description: "\n[keybindings]\nbase = [\n    [\"ToBottom\", { key = \"Space\", mod = [\"Ctrl\", \"Shift\"] }],\n    [\"ZoomOut\", [{ key = \"Space\", mod = [\"Ctrl\", \"Shift\"] }, \"Enter\", 39]],\n]\n"
+expression: err
+---
+A keycombo starts with another keycombo making it unreachable
+	Combo: <Ctrl+Shift+Space><Enter><scan code: 39>
+	Prefix: <Ctrl+Shift+Space>


### PR DESCRIPTION
I'd say the snapshots speak for themselves in terms of the improvement