### PR TITLE
fix: filter file watcher duplicate events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,6 +1161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1887,7 @@ dependencies = [
  "lyon",
  "lz4_flex",
  "notify",
+ "notify-debouncer-full",
  "open",
  "pollster",
  "pretty_assertions",
@@ -2499,6 +2509,19 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ two-face = "0.3.0"
 # Required for WGPU to work properly with Vulkan
 fontdb = { version = "0.13.1", features = ["fontconfig"] }
 human-panic = "1.2.2"
+notify-debouncer-full = { version = "0.3.1", default-features = false }
 
 [dependencies.glyphon]
 version = "0.2"

--- a/src/file_watcher/mod.rs
+++ b/src/file_watcher/mod.rs
@@ -50,7 +50,7 @@ impl DebounceEventHandler for MsgHandler {
                 // Remove is more interesting than Modify
                 for ev in events {
                     match ev.event.kind {
-                        EventKind::Modify(_) => {
+                        EventKind::Create(_) | EventKind::Modify(_) => {
                             let _ = selected_event.get_or_insert(ev.event);
                         }
                         EventKind::Remove(_) => {
@@ -144,7 +144,7 @@ fn endlessly_handle_messages<C: Callback>(
                     poll_registering_watcher(watcher, &file_path);
                     log::debug!("Successfully re-registered file watcher");
                     reload_callback.file_reload();
-                } else if matches!(event.kind, EventKind::Modify(_)) {
+                } else if matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_)) {
                     log::debug!("Reloading file");
                     reload_callback.file_reload();
                 }

--- a/src/file_watcher/mod.rs
+++ b/src/file_watcher/mod.rs
@@ -47,14 +47,14 @@ impl DebounceEventHandler for MsgHandler {
                 let mut selected_event: Option<Event> = None;
 
                 // select the most interesting event
-                // Remove is more interesting than Modify
+                // Rename/Remove is more interesting than changing the contents
                 for ev in events {
                     match ev.event.kind {
+                        EventKind::Modify(ModifyKind::Name(_)) | EventKind::Remove(_) => {
+                            let _ = selected_event.insert(ev.event);
+                        }
                         EventKind::Create(_) | EventKind::Modify(_) => {
                             let _ = selected_event.get_or_insert(ev.event);
-                        }
-                        EventKind::Remove(_) => {
-                            let _ = selected_event.insert(ev.event);
                         }
                         _ => {}
                     }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -166,6 +166,8 @@ impl HtmlInterpreter {
         let mut tok = Tokenizer::new(self, TokenizerOpts::default());
 
         for md_string in receiver {
+            log::debug!("Recieved markdown for interpretation: {} bytes", md_string.len());
+
             if tok
                 .sink
                 .should_queue

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -166,7 +166,10 @@ impl HtmlInterpreter {
         let mut tok = Tokenizer::new(self, TokenizerOpts::default());
 
         for md_string in receiver {
-            log::debug!("Recieved markdown for interpretation: {} bytes", md_string.len());
+            log::debug!(
+                "Recieved markdown for interpretation: {} bytes",
+                md_string.len()
+            );
 
             if tok
                 .sink

--- a/src/main.rs
+++ b/src/main.rs
@@ -756,6 +756,7 @@ fn main() -> anyhow::Result<()> {
     human_panic::setup_panic!();
 
     env_logger::Builder::new()
+        .format_timestamp_micros()
         .filter_level(log::LevelFilter::Error)
         .filter_module("inlyne", log::LevelFilter::Info)
         .parse_env("INLYNE_LOG")

--- a/src/main.rs
+++ b/src/main.rs
@@ -756,7 +756,7 @@ fn main() -> anyhow::Result<()> {
     human_panic::setup_panic!();
 
     env_logger::Builder::new()
-        .format_timestamp_micros()
+        .format_timestamp_millis()
         .filter_level(log::LevelFilter::Error)
         .filter_module("inlyne", log::LevelFilter::Info)
         .parse_env("INLYNE_LOG")

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,7 +3,7 @@ use log::LevelFilter;
 pub fn init_test_log() {
     // Ignore errors because other tests in the same binary may have already initialized the logger
     let _ = env_logger::Builder::new()
-        .filter(Some("inlyne"), LevelFilter::Debug)
+        .filter(Some("inlyne"), LevelFilter::Trace)
         .filter(None, LevelFilter::Warn)
         .is_test(true)
         .try_init();


### PR DESCRIPTION
This fixes #198

As discussed in the issue, I refactored the file watcher to use [notify_debouncer_full](https://docs.rs/notify-debouncer-full/latest/notify_debouncer_full/index.html).

I did so with as few modifications as possible to avoid breaking anything. The most interesting part is the `DebounceEventHandler` impl in which I basically filtered unwanted and duplicate events.
The debouncer timeout of 10ms seems good for up to 100 ~ 150Kb files on my machine.

All unit tests passed locally. I've also tested with the files I was having issues with.

I also added logs I found interesting for debugging and changed the log format to show milliseconds since the file_watcher is always faster than a second.