### PR TITLE
refactor: migrate from `log` to `tracing`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,19 +1057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,12 +1737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,7 +1853,6 @@ dependencies = [
  "copypasta",
  "dark-light",
  "dirs 5.0.1",
- "env_logger",
  "filetime",
  "fontdb 0.13.1",
  "fxhash",
@@ -1883,7 +1863,6 @@ dependencies = [
  "image",
  "indexmap 2.1.0",
  "insta",
- "log",
  "lyon",
  "lz4_flex",
  "notify",
@@ -1901,6 +1880,8 @@ dependencies = [
  "tempfile",
  "tiny-skia",
  "toml 0.7.6",
+ "tracing",
+ "tracing-subscriber",
  "two-face",
  "twox-hash",
  "usvg",
@@ -1978,17 +1959,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
-dependencies = [
- "hermit-abi",
- "rustix 0.38.21",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2273,6 +2243,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2522,6 +2501,16 @@ dependencies = [
  "notify",
  "parking_lot",
  "walkdir",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2788,6 +2777,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -3263,8 +3258,17 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.3",
  "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3277,6 +3281,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -3645,6 +3655,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -4034,6 +4053,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4246,6 +4275,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4512,6 +4571,12 @@ checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom 0.2.10",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,6 @@ dirs = "5.0.1"
 serde = { version = "1.0.190", features = ["derive"] }
 toml = "0.7.6"
 reqwest = { version = "0.11.22", default-features = false, features = ["blocking", "json", "rustls-tls", "stream"] }
-log = "0.4.20"
-env_logger = "0.10.0"
 notify = "6.1.1"
 dark-light = "1.0.0"
 # We only decompress our own compressed data, so disable `safe-decode` and
@@ -63,11 +61,12 @@ taffy = { git = "https://github.com/DioxusLabs/taffy", rev = "d338f3731da519d182
 syntect = "5.1.0"
 smart-debug = "0.0.3"
 two-face = "0.3.0"
-
 # Required for WGPU to work properly with Vulkan
 fontdb = { version = "0.13.1", features = ["fontconfig"] }
 human-panic = "1.2.2"
 notify-debouncer-full = { version = "0.3.1", default-features = false }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dependencies.glyphon]
 version = "0.2"

--- a/src/file_watcher/mod.rs
+++ b/src/file_watcher/mod.rs
@@ -56,7 +56,7 @@ struct MsgHandler(mpsc::Sender<WatcherMsg>);
 
 impl DebounceEventHandler for MsgHandler {
     fn handle_event(&mut self, debounced_event: DebounceEventResult) {
-        log::debug!("Received debounced file events: {:#?}", debounced_event);
+        tracing::debug!("Received debounced file events: {:#?}", debounced_event);
 
         match debounced_event {
             Ok(events) => {
@@ -80,12 +80,12 @@ impl DebounceEventHandler for MsgHandler {
                     let msg = WatcherMsg::Action(action);
                     let _ = self.0.send(msg);
                 } else {
-                    log::trace!("Ignoring events")
+                    tracing::trace!("Ignoring events")
                 }
             }
             Err(errs) => {
                 for err in errs {
-                    log::warn!("File watcher error: {err}");
+                    tracing::warn!("File watcher error: {err}");
                 }
             }
         }
@@ -145,17 +145,17 @@ fn endlessly_handle_messages<C: Callback>(
     while let Ok(msg) = msg_rx.recv() {
         match msg {
             WatcherMsg::Action(DebouncerAction::ReregisterWatcher) => {
-                log::debug!("File may have been renamed/removed. Falling back to polling");
+                tracing::debug!("File may have been renamed/removed. Falling back to polling");
                 poll_registering_watcher(watcher, &file_path);
-                log::debug!("Successfully re-registered file watcher");
+                tracing::debug!("Successfully re-registered file watcher");
                 reload_callback.file_reload();
             }
             WatcherMsg::Action(DebouncerAction::FileReload) => {
-                log::debug!("Reloading file");
+                tracing::debug!("Reloading file");
                 reload_callback.file_reload();
             }
             WatcherMsg::FileChange(FileChange { new_path, contents }) => {
-                log::info!("Updating file watcher path: {}", new_path.display());
+                tracing::info!("Updating file watcher path: {}", new_path.display());
                 let _ = watcher.unwatch(&file_path);
                 poll_registering_watcher(watcher, &new_path);
                 file_path = new_path;
@@ -164,5 +164,5 @@ fn endlessly_handle_messages<C: Callback>(
         }
     }
 
-    log::warn!("File watcher channel dropped unexpectedly");
+    tracing::warn!("File watcher channel dropped unexpectedly");
 }

--- a/src/image/decode.rs
+++ b/src/image/decode.rs
@@ -68,7 +68,7 @@ where
     };
 
     let maybe_image_parts = lz4_compress(&mut adapter).ok().map(|lz4_blob| {
-        log::debug!(
+        tracing::debug!(
             "Streaming image decode & compression:\n\
             - Full {:.2} MiB\n\
             - Compressed {:.2} MiB\n\
@@ -183,7 +183,7 @@ fn fallback_decode_and_compress(contents: &[u8]) -> anyhow::Result<(Vec<u8>, (u3
     let image = image::load_from_memory(contents)?;
     let dimensions = image.dimensions();
     let image_data = image.into_rgba8().into_raw();
-    log::debug!(
+    tracing::debug!(
         "Decoded full image in memory {:.3} MiB",
         usize_in_mib(image_data.len()),
     );

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -57,7 +57,7 @@ impl ImageData {
         let start = Instant::now();
         let lz4_blob =
             decode::lz4_compress(&mut io::Cursor::new(image.as_raw())).expect("I/O is in memory");
-        log::debug!(
+        tracing::debug!(
             "Compressing SVG image:\n- Full {:.2} MiB\n- Compressed {:.2} MiB\n- Time {:.2?}",
             usize_in_mib(image.as_raw().len()),
             usize_in_mib(lz4_blob.len()),
@@ -110,7 +110,7 @@ impl Image {
     ) -> Option<Arc<BindGroup>> {
         let dimensions = self.buffer_dimensions()?;
         if dimensions.0 == 0 || dimensions.1 == 0 {
-            log::warn!("Invalid buffer dimensions");
+            tracing::warn!("Invalid buffer dimensions");
             return None;
         }
 
@@ -122,7 +122,7 @@ impl Image {
             .as_ref()
             .map(|image| image.to_bytes())?;
 
-        log::debug!("Decompressing image: Time {:.2?}", start.elapsed());
+        tracing::debug!("Decompressing image: Time {:.2?}", start.elapsed());
 
         let texture_size = wgpu::Extent3d {
             width: dimensions.0,
@@ -200,7 +200,7 @@ impl Image {
             } else if let Ok(bytes) = reqwest::blocking::get(&src).and_then(|resp| resp.bytes()) {
                 bytes.to_vec()
             } else {
-                log::warn!("Request for image from {} failed", src_path.display());
+                tracing::warn!("Request for image from {} failed", src_path.display());
                 return;
             };
 
@@ -212,7 +212,7 @@ impl Image {
                 fontdb.load_system_fonts();
                 // TODO: yes all of this image loading is very messy and could use a refactor
                 let Ok(mut tree) = usvg::Tree::from_data(&image_data, &opt) else {
-                    log::warn!(
+                    tracing::warn!(
                         "Failed loading image:\n- src: {}\n- src_path: {}",
                         src,
                         src_path.display()

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -166,7 +166,7 @@ impl HtmlInterpreter {
         let mut tok = Tokenizer::new(self, TokenizerOpts::default());
 
         for md_string in receiver {
-            log::debug!(
+            tracing::debug!(
                 "Recieved markdown for interpretation: {} bytes",
                 md_string.len()
             );

--- a/src/keybindings/mod.rs
+++ b/src/keybindings/mod.rs
@@ -328,12 +328,12 @@ impl KeyCombos {
             }
         }
 
-        log::debug!("Received key: {modified_key}");
+        tracing::debug!("Received key: {modified_key}");
 
         let maybe_action = self.munch_(modified_key);
 
         if let Some(action) = maybe_action {
-            log::debug!("Emitting action: {:?}", action);
+            tracing::debug!("Emitting action: {:?}", action);
         }
 
         maybe_action

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,10 +1,16 @@
-use log::LevelFilter;
+use tracing_subscriber::prelude::*;
 
 pub fn init_test_log() {
+    let filter = tracing_subscriber::filter::Targets::new()
+        .with_default(tracing_subscriber::filter::LevelFilter::WARN)
+        .with_target("inlyne", tracing_subscriber::filter::LevelFilter::TRACE);
     // Ignore errors because other tests in the same binary may have already initialized the logger
-    let _ = env_logger::Builder::new()
-        .filter(Some("inlyne"), LevelFilter::Trace)
-        .filter(None, LevelFilter::Warn)
-        .is_test(true)
+    let _ = tracing_subscriber::registry()
+        .with(filter)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .with_test_writer(),
+        )
         .try_init();
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -173,7 +173,7 @@ pub fn markdown_to_html(md: &str, syntax_theme: SyntectTheme) -> String {
                 |front_matter| match serde_yaml::from_str::<FrontMatter>(front_matter) {
                     Ok(front_matter) => Some(front_matter.to_table()),
                     Err(err) => {
-                        log::warn!(
+                        tracing::warn!(
                             "Failed parsing front matter. Error: {}\n{}",
                             err,
                             front_matter
@@ -232,7 +232,7 @@ impl Cell {
                 html_escape::encode_safe_to_string(s, buf);
             }
             Self::Table(_v) => {
-                log::warn!("Nested tables aren't supported yet. Skipping");
+                tracing::warn!("Nested tables aren't supported yet. Skipping");
                 buf.push_str("{Skipped nested table}");
             }
         }


### PR DESCRIPTION
Fixes #206

I've migrated `log` to `tracing`.

This is just a simple replacement for now, the logging functions and looks the same. `INLYNE_LOG` still controls the logging and the syntax is the same.