### PR TITLE
fix: reset scroll on markdown navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -521,6 +521,9 @@ impl Inlyne {
                                                         &self.opts.file_path,
                                                         contents,
                                                     );
+                                                    // TODO: Once and if history is implemented,
+                                                    // old scroll_y might be stored there
+                                                    self.renderer.set_scroll_y(0.);
                                                 }
                                                 Err(err) => {
                                                     tracing::warn!(


### PR DESCRIPTION
Fixes #202

Reset the scroll to top when navigating markdown files.

I think it's worth adding a test for this but I don't know where that would be.