### PR TITLE
chore: update glyphon to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "addr2line"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +53,12 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-activity"
@@ -661,15 +661,16 @@ dependencies = [
 
 [[package]]
 name = "cosmic-text"
-version = "0.8.0"
-source = "git+https://github.com/trimental/cosmic-text?rev=e1e9fb5215daa9dbd40998e16210a6ee3a61ff1f#e1e9fb5215daa9dbd40998e16210a6ee3a61ff1f"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b68966c2543609f8d92f9d33ac3b719b2a67529b0c6c0b3e025637b477eef9"
 dependencies = [
- "fontdb 0.13.1",
+ "aliasable",
+ "fontdb 0.14.1",
  "libm",
  "log",
- "ouroboros",
  "rangemap",
- "rustybuzz 0.7.0",
+ "rustybuzz 0.8.0",
  "swash",
  "sys-locale",
  "unicode-bidi",
@@ -1074,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "etagere"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6301151a318f367f392c31395beb1cfba5ccd9abc44d1db0db3a4b27b9601c89"
+checksum = "306960881d6c46bd0dd6b7f07442a441418c08d0d3e63d8d080b0f64c6343e4e"
 dependencies = [
  "euclid",
  "svg_fmt",
@@ -1232,6 +1233,19 @@ dependencies = [
  "memmap2 0.5.10",
  "slotmap",
  "ttf-parser 0.18.1",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8d8cbea8f21307d7e84bca254772981296f058a1d36b461bf4d83a7499fc9e"
+dependencies = [
+ "log",
+ "memmap2 0.6.2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.19.0",
 ]
 
 [[package]]
@@ -1484,8 +1498,9 @@ dependencies = [
 
 [[package]]
 name = "glyphon"
-version = "0.2.0"
-source = "git+https://github.com/trimental/glyphon?rev=5bf8b6b6aa4a181824798836e1436809e78102e7#5bf8b6b6aa4a181824798836e1436809e78102e7"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e87caa7459145f5e5f167bf34db4532901404c679e62339fb712a0e3ccf722a"
 dependencies = [
  "cosmic-text",
  "etagere",
@@ -1590,18 +1605,13 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.3",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hassle-rs"
@@ -2145,11 +2155,11 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lru"
-version = "0.9.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e7d46de488603ffdd5f30afbc64fbba2378214a2c3a2fb83abf3d33126df17"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.2",
 ]
 
 [[package]]
@@ -2262,6 +2272,15 @@ name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
 dependencies = [
  "libc",
 ]
@@ -2756,29 +2775,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ouroboros"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
-dependencies = [
- "Inflector",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,30 +3014,6 @@ checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
  "toml_edit 0.19.14",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -3485,15 +3457,15 @@ dependencies = [
 
 [[package]]
 name = "rustybuzz"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a"
+checksum = "82eea22c8f56965eeaf3a209b3d24508256c7b920fb3b6211b8ba0f7c0583250"
 dependencies = [
  "bitflags 1.3.2",
  "bytemuck",
  "libm",
  "smallvec",
- "ttf-parser 0.18.1",
+ "ttf-parser 0.19.0",
  "unicode-bidi-mirroring",
  "unicode-ccc",
  "unicode-general-category",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,7 @@ human-panic = "1.2.2"
 notify-debouncer-full = { version = "0.3.1", default-features = false }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-
-[dependencies.glyphon]
-version = "0.2"
-git = "https://github.com/trimental/glyphon"
-rev = "5bf8b6b6aa4a181824798836e1436809e78102e7"
+glyphon = "0.3"
 
 [profile.release]
 strip = true

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -11,9 +11,9 @@ use crate::text::{CachedTextArea, TextCache, TextSystem};
 use crate::utils::{Point, Rect, Selection, Size};
 use crate::Element;
 
-use anyhow::{anyhow, Context, Ok};
+use anyhow::{Context, Ok};
 use bytemuck::{Pod, Zeroable};
-use glyphon::{PrepareError, Resolution, SwashCache, TextArea, TextAtlas, TextRenderer};
+use glyphon::{Resolution, SwashCache, TextArea, TextAtlas, TextRenderer};
 use lyon::geom::euclid::Point2D;
 use lyon::geom::Box2D;
 use lyon::path::Polygon;
@@ -757,24 +757,18 @@ impl Renderer {
                 .map(|c| c.text_area(&text_cache))
                 .collect();
 
-            while let Result::Err(PrepareError::AtlasFull(content_type)) =
-                self.text_system.text_renderer.prepare(
-                    &self.device,
-                    &self.queue,
-                    &mut self.text_system.font_system.lock().unwrap(),
-                    &mut self.text_system.text_atlas,
-                    Resolution {
-                        width: self.config.width,
-                        height: self.config.height,
-                    },
-                    &text_areas,
-                    &mut self.text_system.swash_cache,
-                )
-            {
-                if !self.text_system.text_atlas.grow(&self.device, content_type) {
-                    return Err(anyhow!("Could not grow text atlas"));
-                }
-            }
+            self.text_system.text_renderer.prepare(
+                &self.device,
+                &self.queue,
+                &mut self.text_system.font_system.lock().unwrap(),
+                &mut self.text_system.text_atlas,
+                Resolution {
+                    width: self.config.width,
+                    height: self.config.height,
+                },
+                text_areas,
+                &mut self.text_system.swash_cache,
+            )?;
             text_cache.trim();
         }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -9,7 +9,7 @@ use crate::utils::{Align, Line, Point, Rect, Selection, Size};
 
 use fxhash::{FxHashMap, FxHashSet};
 use glyphon::{
-    Affinity, Attrs, AttrsList, BufferLine, Color, Cursor, FamilyOwned, FontSystem, Style,
+    Affinity, Attrs, AttrsList, BufferLine, Color, Cursor, FamilyOwned, FontSystem, Shaping, Style,
     SwashCache, TextArea, TextBounds, Weight,
 };
 use smart_debug::SmartDebug;
@@ -93,8 +93,8 @@ impl Default for TextBox {
 
 pub struct CachedTextArea {
     key: KeyHash,
-    left: i32,
-    top: i32,
+    left: f32,
+    top: f32,
     bounds: TextBounds,
     default_color: Color,
 }
@@ -107,6 +107,7 @@ impl CachedTextArea {
             top: self.top,
             bounds: self.bounds,
             default_color: self.default_color,
+            scale: 1.,
         }
     }
 }
@@ -282,8 +283,8 @@ impl TextBox {
 
         CachedTextArea {
             key,
-            left: left as i32,
-            top: (screen_position.1 - scroll_y) as i32,
+            left,
+            top: (screen_position.1 - scroll_y),
             bounds: TextBounds::default(),
             default_color: Color::rgb(255, 255, 255),
         }
@@ -651,7 +652,7 @@ impl TextCache {
                             .metadata(section.index),
                     )
                 }
-                let buffer_line = BufferLine::new(line_str, attrs_list);
+                let buffer_line = BufferLine::new(line_str, attrs_list, Shaping::Advanced);
                 buffer.lines.push(buffer_line);
             }
 


### PR DESCRIPTION
This updates glyphon the latest version.

There is still one change I need help with (marked below).

EDIT: I'll test the changes locally once I can get it to compile.