### PR TITLE
fix: typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ _If you're wondering 'Is this relevant to me?' Then the answer is probably no
 - [ ] Check for unused dependencies
   - `$ cargo +nightly udeps`
 - [ ] Bump `version` in `Cargo.toml`
-- [ ] Propogate the change to `Cargo.lock`
+- [ ] Propagate the change to `Cargo.lock`
   - `$ cargo check -p inlyne`
 - [ ] Optional: If making a breaking release update the `example.png` link in
   the README to point to the appropriate release branch

--- a/src/color.rs
+++ b/src/color.rs
@@ -139,7 +139,7 @@ impl<'de> Deserialize<'de> for SyntaxTheme {
 
         match untagged {
             // Unfortunately #[serde(untagged)] uses private internals to reuse a deserializer
-            // mutliple times. We can't so now we have to fall back to other means to give a good
+            // multiple times. We can't so now we have to fall back to other means to give a good
             // error message ;-;
             Untagged::Defaults(theme_name) => match ThemeDefaults::from_kebab(&theme_name) {
                 Some(theme) => Ok(Self::Defaults(theme)),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -167,7 +167,7 @@ impl HtmlInterpreter {
 
         for md_string in receiver {
             tracing::debug!(
-                "Recieved markdown for interpretation: {} bytes",
+                "Received markdown for interpretation: {} bytes",
                 md_string.len()
             );
 


### PR DESCRIPTION
Just fixed some small typos.

Do you think it is useful to include [`typos-cli`](https://github.com/crate-ci/typos) in the CI? (That's what I used to find those)