### PR TITLE
fix(text): fix substract with overflow panic

### DIFF
--- a/src/text.rs
+++ b/src/text.rs
@@ -177,6 +177,7 @@ impl TextBox {
         }
     }
 
+    /// Returns the [`Text`] in the given [`TextSystem`] with the cursor over it, if any.
     pub fn find_hoverable<'a>(
         &'a self,
         text_system: &mut TextSystem,
@@ -200,8 +201,7 @@ impl TextBox {
             let line = &buffer.lines[cursor.line];
             let mut index = cursor.index;
             if cursor.affinity == Affinity::Before {
-                // FIXME (Can we assume that the glyph is 1 index wide)
-                index -= 1;
+                index = index.saturating_sub(1);
             }
             let text = &self.texts[line.attrs_list().get_span(index).metadata];
             Some(text)


### PR DESCRIPTION
Fixes https://github.com/trimental/inlyne/issues/197

This change avoids the panic, _visually_ the behavior is the same.
However I'm not sure this is correct, because it means sometimes it won't be subtracted (and we get a wrong index?).

---

I don't get why we would need to subtract one to the index of the glyph under the cursor only if the cursor is associated with the previous frame. Also removing this `if Affinity::Before` altogether doesn't seem to change anything ...
Have I misunderstood something in my reasoning?