### PR TITLE
fix(table): table alignment wasn't reset properly

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -290,14 +290,12 @@ impl TokenSink for HtmlInterpreter {
                         }
                         "th" => {
                             self.state.text_options.bold += 1;
-                            if let Some(align) = html::find_align(&tag.attrs) {
-                                self.current_textbox.set_align(align);
-                            }
+                            let align = html::find_align(&tag.attrs);
+                            self.current_textbox.set_align(align.unwrap_or(Align::Left));
                         }
                         "td" => {
-                            if let Some(align) = html::find_align(&tag.attrs) {
-                                self.current_textbox.set_align(align);
-                            }
+                            let align = html::find_align(&tag.attrs);
+                            self.current_textbox.set_align(align.unwrap_or(Align::Left));
                         }
                         "table" => {
                             self.push_spacer();

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__aligned_table.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__aligned_table.snap
@@ -1,0 +1,132 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n| left default | left forced | centered | right | left default |\n| ------------ | :---------- | :------: | ----: | ------------ |\n| text         | text        |   text   |  text | text         |\n\n\n --- html\n\n<table>\n<thead>\n<tr>\n<th>left default</th>\n<th align=\"left\">left forced</th>\n<th align=\"center\">centered</th>\n<th align=\"right\">right</th>\n<th>left default</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>text</td>\n<td align=\"left\">text</td>\n<td align=\"center\">text</td>\n<td align=\"right\">text</td>\n<td>text</td>\n</tr>\n</tbody>\n</table>\n"
+expression: interpret_md(text)
+---
+[
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    Table(
+        Table {
+            headers: [
+                TextBox {
+                    texts: [
+                        Text {
+                            text: "left default",
+                            default_color: Color(BLACK),
+                            style: BOLD ,
+                            ..
+                        },
+                    ],
+                    ..
+                },
+                TextBox {
+                    texts: [
+                        Text {
+                            text: "left forced",
+                            default_color: Color(BLACK),
+                            style: BOLD ,
+                            ..
+                        },
+                    ],
+                    ..
+                },
+                TextBox {
+                    align: Center,
+                    texts: [
+                        Text {
+                            text: "centered",
+                            default_color: Color(BLACK),
+                            style: BOLD ,
+                            ..
+                        },
+                    ],
+                    ..
+                },
+                TextBox {
+                    align: Right,
+                    texts: [
+                        Text {
+                            text: "right",
+                            default_color: Color(BLACK),
+                            style: BOLD ,
+                            ..
+                        },
+                    ],
+                    ..
+                },
+                TextBox {
+                    texts: [
+                        Text {
+                            text: "left default",
+                            default_color: Color(BLACK),
+                            style: BOLD ,
+                            ..
+                        },
+                    ],
+                    ..
+                },
+            ],
+            rows: [
+                [
+                    TextBox {
+                        texts: [
+                            Text {
+                                text: "text",
+                                default_color: Color(BLACK),
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        texts: [
+                            Text {
+                                text: "text",
+                                default_color: Color(BLACK),
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        align: Center,
+                        texts: [
+                            Text {
+                                text: "text",
+                                default_color: Color(BLACK),
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        align: Right,
+                        texts: [
+                            Text {
+                                text: "text",
+                                default_color: Color(BLACK),
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        texts: [
+                            Text {
+                                text: "text",
+                                default_color: Color(BLACK),
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                ],
+            ],
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -221,6 +221,12 @@ tags:
 # Markdown h1 header
 ";
 
+const ALIGNED_TABLE: &str = "\
+| left default | left forced | centered | right | left default |
+| ------------ | :---------- | :------: | ----: | ------------ |
+| text         | text        |   text   |  text | text         |
+";
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
@@ -234,6 +240,7 @@ snapshot_interpreted_elements!(
     (para_in_ordered_list, PARA_IN_ORDERED_LIST),
     (code_in_ordered_list, CODE_IN_ORDERED_LIST),
     (yaml_frontmatter, YAML_FRONTMATTER),
+    (aligned_table, ALIGNED_TABLE),
 );
 
 /// Spin up a server, so we can test network requests without external services


### PR DESCRIPTION
While working on https://github.com/trimental/inlyne/issues/141 I found a bug in the table alignment that I would like to fix first.

Each cell, if no explicit alignment specified, retain the alignment of the previous cell. This also occurred across table.

---

Assume the following table:
```
| left default | left forced | centered | right | left default |
| ------------ | :---------- | :------: | ----: | ------------ |
| text         | text        |   text   |  text | text         |
```

On main:
![image](https://github.com/trimental/inlyne/assets/36198422/23ce802a-e438-4a2d-93a6-e5e1815b58c6)

With this fix:
![image](https://github.com/trimental/inlyne/assets/36198422/d7ebd21e-0bf0-4d0a-b8e5-5d358b00aaa2)