### PR TITLE
Expose additional `two-face` themes

### DIFF
--- a/inlyne.default.toml
+++ b/inlyne.default.toml
@@ -39,9 +39,15 @@ select-color = 0x3675cb
 checkbox-color = 0x0a5301
 # Syntax highlighting theme. All of `syntect`s default themes are supported
 # Possible values: [
-#     "base16-ocean-dark",  "base16-eighties-dark", "base16-mocha-dark",
-#     "base16-ocean-light", "inspired-github",      "solarized-dark",
-#     "solarized-light"
+#     "base16-eighties-dark", "base16-mocha-dark", "base16-ocean-dark",
+#     "base16-ocean-light",   "coldark-cold",      "coldark-dark",
+#     "dark-neon",            "dracula",           "github",
+#     "gruvbox-dark",         "gruvbox-light",     "leet",
+#     "monokai-extended",     "monokai-extended-light",
+#     "nord",                 "one-half-dark",     "one-half-light",
+#     "solarized-dark",       "solarized-light",   "sublime-snazzy",
+#     "two-dark",             "visual-studio-dark-plus",
+#     "zenburn"
 # ]
 # You can also pass a path to a `.tmTheme` file for a custom theme instead
 # Example:
@@ -57,7 +63,7 @@ quote-block-color = 0xeef9fe
 link-color = 0x5466ff
 select-color = 0xcde8f0
 checkbox-color = 0x96ecae
-code-highlighter = "inspired-github"
+code-highlighter = "github"
 
 # Specify the main and monospace font families
 [font-options]

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__code_block_bg_color.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__code_block_bg_color.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: " --- md\n\n```\nFenced code block with no language tag\n```\n\n```rust\n// Rust code\nfn main() {}\n```\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code><span style=\"color:#323232;\">Fenced code block with no language tag\n</span></code></pre>\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust\"><span style=\"font-style:italic;color:#969896;\">// Rust code\n</span><span style=\"font-weight:bold;color:#a71d5d;\">fn </span><span style=\"font-weight:bold;color:#795da3;\">main</span><span style=\"color:#323232;\">() {}\n</span></code></pre>\n"
+description: " --- md\n\n```\nFenced code block with no language tag\n```\n\n```rust\n// Rust code\nfn main() {}\n```\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code><span style=\"color:#333333;\">Fenced code block with no language tag\n</span></code></pre>\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust\"><span style=\"color:#969896;\">// Rust code\n</span><span style=\"color:#a71d5d;\">fn </span><span style=\"color:#795da3;\">main</span><span style=\"color:#333333;\">() {}\n</span></code></pre>\n"
 expression: interpret_md(text)
 ---
 [
@@ -36,7 +36,6 @@ expression: interpret_md(text)
                     text: "// Rust code",
                     font_family: Monospace,
                     color: Some(Color { r: 0.30, g: 0.31, b: 0.30 }),
-                    style: ITALIC ,
                     ..
                 },
                 Text {
@@ -48,14 +47,12 @@ expression: interpret_md(text)
                     text: "fn ",
                     font_family: Monospace,
                     color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
-                    style: BOLD ,
                     ..
                 },
                 Text {
                     text: "main",
                     font_family: Monospace,
                     color: Some(Color { r: 0.19, g: 0.11, b: 0.37 }),
-                    style: BOLD ,
                     ..
                 },
                 Text {

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__code_in_ordered_list.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__code_in_ordered_list.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: " --- md\n\n1. 1st item\n\n    ```rust\n    fn main() {}\n    ```\n\n2. 2nd item\n\n\n --- html\n\n<ol>\n<li>\n<p>1st item</p>\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust\"><span style=\"font-weight:bold;color:#a71d5d;\">fn </span><span style=\"font-weight:bold;color:#795da3;\">main</span><span style=\"color:#323232;\">() {}\n</span></code></pre>\n</li>\n<li>\n<p>2nd item</p>\n</li>\n</ol>\n"
+description: " --- md\n\n1. 1st item\n\n    ```rust\n    fn main() {}\n    ```\n\n2. 2nd item\n\n\n --- html\n\n<ol>\n<li>\n<p>1st item</p>\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust\"><span style=\"color:#a71d5d;\">fn </span><span style=\"color:#795da3;\">main</span><span style=\"color:#333333;\">() {}\n</span></code></pre>\n</li>\n<li>\n<p>2nd item</p>\n</li>\n</ol>\n"
 expression: interpret_md(text)
 ---
 [
@@ -36,14 +36,12 @@ expression: interpret_md(text)
                     text: "fn ",
                     font_family: Monospace,
                     color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
-                    style: BOLD ,
                     ..
                 },
                 Text {
                     text: "main",
                     font_family: Monospace,
                     color: Some(Color { r: 0.19, g: 0.11, b: 0.37 }),
-                    style: BOLD ,
                     ..
                 },
                 Text {

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__handles_comma_in_info_str.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__handles_comma_in_info_str.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: " --- md\n\n```rust,ignore\nlet v = 1;\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust,ignore\"><span style=\"font-weight:bold;color:#a71d5d;\">let</span><span style=\"color:#323232;\"> v </span><span style=\"font-weight:bold;color:#a71d5d;\">= </span><span style=\"color:#0086b3;\">1</span><span style=\"color:#323232;\">;\n</span></code></pre>\n"
+description: " --- md\n\n```rust,ignore\nlet v = 1;\n```\n\n\n --- html\n\n<pre style=\"background-color:#f6f8fa;\"><code class=\"language-rust,ignore\"><span style=\"color:#a71d5d;\">let</span><span style=\"color:#333333;\"> v </span><span style=\"color:#a71d5d;\">= </span><span style=\"color:#0086b3;\">1</span><span style=\"color:#333333;\">;\n</span></code></pre>\n"
 expression: interpret_md(text)
 ---
 [
@@ -13,7 +13,6 @@ expression: interpret_md(text)
                     text: "let",
                     font_family: Monospace,
                     color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
-                    style: BOLD ,
                     ..
                 },
                 Text {
@@ -26,7 +25,6 @@ expression: interpret_md(text)
                     text: "= ",
                     font_family: Monospace,
                     color: Some(Color { r: 0.39, g: 0.01, b: 0.11 }),
-                    style: BOLD ,
                     ..
                 },
                 Text {

--- a/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__unknown_theme.snap
+++ b/src/opts/tests/snapshots/inlyne__opts__tests__error_msg__unknown_theme.snap
@@ -7,5 +7,5 @@ TOML parse error at line 1, column 32
   |
 1 | light-theme.code-highlighter = "doesnt-exist"
   |                                ^^^^^^^^^^^^^^
-"doesnt-exist" didn't match any of the expected variants: ["base16-ocean-dark", "base16-eighties-dark", "base16-mocha-dark", "base16-ocean-light", "inspired-github", "solarized-dark", "solarized-light"]
+"doesnt-exist" didn't match any of the expected variants: ["base16-eighties-dark", "base16-mocha-dark", "base16-ocean-dark", "base16-ocean-light", "coldark-cold", "coldark-dark", "dark-neon", "dracula", "github", "gruvbox-dark", "gruvbox-light", "leet", "monokai-extended", "monokai-extended-light", "nord", "one-half-dark", "one-half-light", "solarized-dark", "solarized-light", "sublime-snazzy", "two-dark", "visual-studio-dark-plus", "zenburn"]
 


### PR DESCRIPTION
This switches the exposed embedded themes to a subset of all the themes provided by `two-face`. Namely I left out themes that didn't seem unique enough:

- `InspiredGithub` (compared to `Github`)
- `MonokaiExtendedBright`, and `MonokaiExtendedOrigin` (compared to `MonokaiExtended`)

Along with several others that don't make sense in `inlyne`'s context:

- `Ansi`
- `Base16`
- `Base16_256`