### PR TITLE
Add support for colored underlines and strikethroughs

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -329,12 +329,9 @@ impl Renderer {
                         bounds,
                         self.zoom,
                     ) {
-                        let min = (line.0 .0, line.0 .1);
-                        let max = (line.1 .0, line.1 .1 + 2. * self.hidpi_scale * self.zoom);
-                        self.draw_rectangle(
-                            Rect::from_min_max(min, max),
-                            native_color(self.theme.text_color, &self.surface_format),
-                        )?;
+                        let min = (line.min.0, line.min.1);
+                        let max = (line.max.0, line.max.1 + 2. * self.hidpi_scale * self.zoom);
+                        self.draw_rectangle(Rect::from_min_max(min, max), line.color)?;
                     }
                     if let Some(selection) = self.selection {
                         let (selection_rects, selection_text) = text_box.render_selection(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,11 +21,23 @@ pub fn usize_in_mib(num: usize) -> f32 {
     num as f32 / 1_024.0 / 1_024.0
 }
 
-pub type Line = ((f32, f32), (f32, f32));
 pub type Selection = ((f32, f32), (f32, f32));
 pub type Point = (f32, f32);
 pub type Size = (f32, f32);
 pub type ImageCache = Arc<Mutex<HashMap<String, Arc<Mutex<Option<ImageData>>>>>>;
+
+#[derive(Debug, Clone)]
+pub struct Line {
+    pub min: Point,
+    pub max: Point,
+    pub color: [f32; 4],
+}
+
+impl Line {
+    pub fn with_color(min: Point, max: Point, color: [f32; 4]) -> Self {
+        Self { min, max, color }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct Rect {


### PR DESCRIPTION
In #221 it was noticed that underlines for colored text still use the default text color. This PR threads the color through to match the text color for underlines and strikethroughs

![image](https://github.com/trimental/inlyne/assets/30302768/3b34922e-091d-4319-ac73-cabecce85103)
