### PR TITLE
Make underlines and strikethroughs respect align

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -246,8 +246,7 @@ impl Renderer {
                         self.zoom,
                         self.scroll_y,
                     );
-                    let text_left = areas.left();
-                    text_areas.push(areas);
+                    text_areas.push(areas.clone());
                     if text_box.is_code_block || text_box.is_quote_block.is_some() {
                         let color = if let Some(bg_color) = text_box.background_color {
                             bg_color
@@ -330,7 +329,7 @@ impl Renderer {
                         scrolled_pos,
                         bounds,
                         self.zoom,
-                        text_left,
+                        &areas,
                     ) {
                         let min = (line.min.0, line.min.1);
                         let max = (line.max.0, line.max.1 + 2. * self.hidpi_scale * self.zoom);

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -239,13 +239,15 @@ impl Renderer {
                         f32::INFINITY,
                     );
 
-                    text_areas.push(text_box.text_areas(
+                    let areas = text_box.text_areas(
                         &mut self.text_system,
                         pos,
                         bounds,
                         self.zoom,
                         self.scroll_y,
-                    ));
+                    );
+                    let text_left = areas.left();
+                    text_areas.push(areas);
                     if text_box.is_code_block || text_box.is_quote_block.is_some() {
                         let color = if let Some(bg_color) = text_box.background_color {
                             bg_color
@@ -328,6 +330,7 @@ impl Renderer {
                         scrolled_pos,
                         bounds,
                         self.zoom,
+                        text_left,
                     ) {
                         let min = (line.min.0, line.min.1);
                         let max = (line.max.0, line.max.1 + 2. * self.hidpi_scale * self.zoom);

--- a/src/text.rs
+++ b/src/text.rs
@@ -92,6 +92,7 @@ impl Default for TextBox {
     }
 }
 
+#[derive(Clone)]
 pub struct CachedTextArea {
     key: KeyHash,
     left: f32,
@@ -101,10 +102,6 @@ pub struct CachedTextArea {
 }
 
 impl CachedTextArea {
-    pub fn left(&self) -> f32 {
-        self.left
-    }
-
     pub fn text_area<'a>(&self, cache: &'a TextCache) -> TextArea<'a> {
         TextArea {
             buffer: cache.get(&self.key).expect("Get cached buffer"),
@@ -301,7 +298,7 @@ impl TextBox {
         screen_position: Point,
         bounds: Size,
         zoom: f32,
-        left: f32,
+        text_area: &CachedTextArea,
     ) -> Vec<Line> {
         fn push_line_segment(
             lines: &mut Vec<ThinLine>,
@@ -377,7 +374,7 @@ impl TextBox {
                 let start_cursor = Cursor::new(line.line_i, range.start);
                 let end_cursor = Cursor::new(line.line_i, range.end);
                 if let Some((highlight_x, highlight_w)) = line.highlight(start_cursor, end_cursor) {
-                    let x = left + highlight_x;
+                    let x = text_area.left + highlight_x;
                     let min = (x.floor(), y);
                     let max = ((x + highlight_w).ceil(), y);
                     let line = Line::with_color(min, max, *color);

--- a/src/text.rs
+++ b/src/text.rs
@@ -101,6 +101,10 @@ pub struct CachedTextArea {
 }
 
 impl CachedTextArea {
+    pub fn left(&self) -> f32 {
+        self.left
+    }
+
     pub fn text_area<'a>(&self, cache: &'a TextCache) -> TextArea<'a> {
         TextArea {
             buffer: cache.get(&self.key).expect("Get cached buffer"),
@@ -297,6 +301,7 @@ impl TextBox {
         screen_position: Point,
         bounds: Size,
         zoom: f32,
+        left: f32,
     ) -> Vec<Line> {
         fn push_line_segment(
             lines: &mut Vec<ThinLine>,
@@ -372,7 +377,7 @@ impl TextBox {
                 let start_cursor = Cursor::new(line.line_i, range.start);
                 let end_cursor = Cursor::new(line.line_i, range.end);
                 if let Some((highlight_x, highlight_w)) = line.highlight(start_cursor, end_cursor) {
-                    let x = screen_position.0 + highlight_x;
+                    let x = left + highlight_x;
                     let min = (x.floor(), y);
                     let max = ((x + highlight_w).ceil(), y);
                     let line = Line::with_color(min, max, *color);


### PR DESCRIPTION
Resolves #141 

@Valentin271 I got a better idea of the underline code after working on #225. The fix _feels_ hacky, but I'm not really familiar with the renderer and there's a lot of messy code in there to begin with :shrug:

From what I can gather `left` gets set to the x coord of the text area including the `Align`

## Demo

(Includes the use of `--page-width` to check that too)

https://github.com/trimental/inlyne/assets/30302768/107b09f1-e6f4-490e-9484-b259fb3fde88

