### PR TITLE
Switch to `comrak`'s anchorizer

### DIFF
--- a/src/interpreter/snapshots/inlyne__interpreter__tests__unique_anchors.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__unique_anchors.snap
@@ -1,0 +1,49 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n# Foo\n# Foo\n\n\n --- html\n\n<h1>Foo</h1>\n<h1>Foo</h1>\n"
+expression: "interpret_md_with_opts(text, opts)"
+---
+[
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            font_size: 32.0,
+            is_anchor: Some("#foo"),
+            texts: [
+                Text {
+                    text: "Foo",
+                    default_color: Color(BLACK),
+                    style: BOLD UNDERLINED ,
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            font_size: 32.0,
+            is_anchor: Some("#foo"),
+            texts: [
+                Text {
+                    text: "Foo",
+                    default_color: Color(BLACK),
+                    style: BOLD UNDERLINED ,
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__unique_anchors.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__unique_anchors.snap
@@ -31,7 +31,7 @@ expression: "interpret_md_with_opts(text, opts)"
     TextBox(
         TextBox {
             font_size: 32.0,
-            is_anchor: Some("#foo"),
+            is_anchor: Some("#foo-1"),
             texts: [
                 Text {
                     text: "Foo",

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -19,13 +19,8 @@ use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 
 // We use a dummy window with an internal counter that keeps track of when rendering a single md
 // document is finished
+#[derive(Clone)]
 struct AtomicCounter(Arc<AtomicU32>);
-
-impl Clone for AtomicCounter {
-    fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
-    }
-}
 
 impl AtomicCounter {
     fn new() -> Self {
@@ -302,6 +297,11 @@ const ALIGNED_TABLE: &str = "\
 | text         | text        |   text   |  text | text         |
 ";
 
+const UNIQUE_ANCHORS: &str = "\
+# Foo
+# Foo
+";
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
@@ -316,6 +316,7 @@ snapshot_interpreted_elements!(
     (code_in_ordered_list, CODE_IN_ORDERED_LIST),
     (yaml_frontmatter, YAML_FRONTMATTER),
     (aligned_table, ALIGNED_TABLE),
+    (unique_anchors, UNIQUE_ANCHORS),
 );
 
 const UNDERLINE_IN_CODEBLOCK: &str = "\


### PR DESCRIPTION
Fixes #204 

`comrak`'s anchorizer is a much better fit for a markdown anchorizer than our home-rolled version

Note: (from [the docs](https://docs.rs/comrak/latest/comrak/html/struct.Anchorizer.html))

> ...
>
> To guarantee uniqueness, an anchorizer keeps track of the anchors it has returned. So, for example, to parse several MarkDown files, use a new anchorizer per file.

Resetting the anchorizer is handled by `State` (which contains the anchorizer) getting reset before each markdown file gets processed