### PR TITLE
Allow for `px` suffix on pixel length

### DIFF
--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -340,7 +340,7 @@ impl Image {
             }
         }
         let max_width = screen_size.0 - 2. * DEFAULT_MARGIN;
-        let dimensions = if let Some(size) = self.size.clone() {
+        let dimensions = if let Some(size) = self.size {
             let dimensions = self.dimensions_from_image_size(&size)?;
             let target_dimensions = (
                 (dimensions.0 as f32 * self.hidpi_scale * zoom) as u32,

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -22,14 +22,14 @@ use usvg::{TreeParsing, TreeTextToPath};
 use wgpu::util::DeviceExt;
 use wgpu::{BindGroup, Device, TextureFormat};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Px(u32);
 
 impl FromStr for Px {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let px: u32 = s.parse()?;
+        let px: u32 = s.strip_suffix("px").unwrap_or(s).parse()?;
         Ok(Self(px))
     }
 }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -4,6 +4,7 @@ mod tests;
 
 use std::borrow::Cow;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use std::{fs, io};
@@ -21,10 +22,38 @@ use usvg::{TreeParsing, TreeTextToPath};
 use wgpu::util::DeviceExt;
 use wgpu::{BindGroup, Device, TextureFormat};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
+pub struct Px(u32);
+
+impl FromStr for Px {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let px: u32 = s.parse()?;
+        Ok(Self(px))
+    }
+}
+
+impl From<u32> for Px {
+    fn from(px: u32) -> Self {
+        Self(px)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum ImageSize {
-    PxWidth(u32),
-    PxHeight(u32),
+    PxWidth(Px),
+    PxHeight(Px),
+}
+
+impl ImageSize {
+    pub fn width<P: Into<Px>>(px: P) -> Self {
+        Self::PxWidth(px.into())
+    }
+
+    pub fn height<P: Into<Px>>(px: P) -> Self {
+        Self::PxHeight(px.into())
+    }
 }
 
 #[derive(SmartDebug, Default, Clone)]
@@ -285,13 +314,14 @@ impl Image {
         let image_dimensions = self.buffer_dimensions()?;
         match size {
             ImageSize::PxWidth(px_width) => Some((
-                *px_width,
-                ((*px_width as f32 / image_dimensions.0 as f32) * image_dimensions.1 as f32) as u32,
+                px_width.0,
+                ((px_width.0 as f32 / image_dimensions.0 as f32) * image_dimensions.1 as f32)
+                    as u32,
             )),
             ImageSize::PxHeight(px_height) => Some((
-                ((*px_height as f32 / image_dimensions.1 as f32) * image_dimensions.0 as f32)
+                ((px_height.0 as f32 / image_dimensions.1 as f32) * image_dimensions.0 as f32)
                     as u32,
-                *px_height,
+                px_height.0,
             )),
         }
     }

--- a/src/image/tests.rs
+++ b/src/image/tests.rs
@@ -1,8 +1,14 @@
 use std::path::Path;
 use std::{fmt, fs};
 
-use super::ImageData;
+use super::{ImageData, Px};
 use crate::test_utils::init_test_log;
+
+#[test]
+fn px_parsing() {
+    assert_eq!("500".parse::<Px>().unwrap(), Px(500));
+    assert_eq!("500px".parse::<Px>().unwrap(), Px(500));
+}
 
 // Checks that the image crate converting to RGBA8 is the same as our technique
 fn check(input_path: &Path) {

--- a/src/interpreter/html.rs
+++ b/src/interpreter/html.rs
@@ -1,6 +1,6 @@
 use std::slice;
 
-use crate::utils::Align;
+use crate::{image::Px, utils::Align};
 
 use html5ever::{local_name, Attribute};
 
@@ -65,8 +65,8 @@ pub enum Attr {
     Align(Align),
     Href(String),
     Anchor(String),
-    Width(u32),
-    Height(u32),
+    Width(Px),
+    Height(Px),
     Src(String),
     Start(usize),
     Style(String),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -359,8 +359,8 @@ impl HtmlInterpreter {
                 for attr in AttrIter::new(&tag.attrs) {
                     match attr {
                         Attr::Align(a) => align = Some(a),
-                        Attr::Width(w) => size = Some(ImageSize::PxWidth(w)),
-                        Attr::Height(h) => size = Some(ImageSize::PxHeight(h)),
+                        Attr::Width(w) => size = Some(ImageSize::width(w)),
+                        Attr::Height(h) => size = Some(ImageSize::height(h)),
                         Attr::Src(s) => src = Some(s),
                         _ => {}
                     }

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__centered_image_with_size_align_and_link.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__centered_image_with_size_align_and_link.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: "\n<p align=\"center\">\n  <a href=\"https://bun.sh\"><img src=\"http://127.0.0.1:42151/bun_logo.png\" alt=\"Logo\" height=170></a>\n</p>"
+description: "\n<p align=\"center\">\n  <a href=\"https://bun.sh\"><img src=\"http://127.0.0.1:41253/bun_logo.png\" alt=\"Logo\" height=170></a>\n</p>"
 expression: interpret_md(&text)
 ---
 [
@@ -18,7 +18,7 @@ expression: interpret_md(&text)
                 ..
             },
             is_aligned: Some(Center),
-            size: Some(PxHeight(170)),
+            size: Some(PxHeight(Px(170))),
             is_link: Some("https://bun.sh"),
             ..
         },

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -176,7 +176,7 @@ fn interpret_md_with_opts(text: &str, opts: InterpreterOpts) -> VecDeque<Element
 #[macro_export]
 macro_rules! snapshot_interpreted_elements {
     ( $( ($test_name:ident, $md_text:ident) ),* $(,)? ) => {
-        crate::snapshot_interpreted_elements!(
+        $crate::snapshot_interpreted_elements!(
             InterpreterOpts::new(),
             $(
                 ($test_name, $md_text),

--- a/src/keybindings/tests.rs
+++ b/src/keybindings/tests.rs
@@ -21,7 +21,7 @@ base = [
 
     // TODO: move this to a helper somewhere
     let Config { keybindings, .. } = Config::load_from_str(config).unwrap();
-    let mut key_combos = KeyCombos::new(keybindings.into()).unwrap();
+    let mut key_combos = KeyCombos::new(keybindings).unwrap();
 
     let g: ModifiedKey = VirtKey::G.into();
     let l_shift = VirtKey::LShift.into();

--- a/src/opts/tests/error_msg.rs
+++ b/src/opts/tests/error_msg.rs
@@ -40,7 +40,7 @@ snapshot_config_parse_error!(
 
 fn keycombo_conflict_from_config(s: &str) -> anyhow::Result<anyhow::Error> {
     let Config { keybindings, .. } = Config::load_from_str(s)?;
-    let err = KeyCombos::new(keybindings.into()).unwrap_err();
+    let err = KeyCombos::new(keybindings).unwrap_err();
     Ok(err)
 }
 


### PR DESCRIPTION
It's common to see images that specify pixel width/height including a `px` suffix, but `inlyne` would fail to parse the value and silently ignore it instead. This adds support for an optional `px` suffix on the pixel length