### PR TITLE
Reorganize `interpreter`'s HTML code

### DIFF
--- a/src/interpreter/html/element.rs
+++ b/src/interpreter/html/element.rs
@@ -1,4 +1,4 @@
-use super::html::{Header, List, ListType};
+use super::{Header, List, ListType};
 use crate::utils::Align;
 use crate::{Section, Table, TextBox};
 

--- a/src/interpreter/html/mod.rs
+++ b/src/interpreter/html/mod.rs
@@ -1,3 +1,9 @@
+mod element;
+mod tag_name;
+
+pub use element::Element;
+pub use tag_name::TagName;
+
 use std::slice;
 
 use crate::{image::Px, utils::Align};

--- a/src/interpreter/html/mod.rs
+++ b/src/interpreter/html/mod.rs
@@ -1,17 +1,18 @@
+pub mod attr;
 mod element;
+pub mod style;
 mod tag_name;
 
+pub use attr::Attr;
 pub use element::Element;
 pub use tag_name::TagName;
 
-use std::slice;
+use crate::utils::Align;
 
-use crate::{image::Px, utils::Align};
-
-use html5ever::{local_name, Attribute};
+use html5ever::Attribute;
 
 pub fn find_align(attrs: &[Attribute]) -> Option<Align> {
-    AttrIter::new(attrs).find_map(|attr| {
+    attr::Iter::new(attrs).find_map(|attr| {
         if let Attr::Align(align) = attr {
             Some(align)
         } else {
@@ -21,7 +22,7 @@ pub fn find_align(attrs: &[Attribute]) -> Option<Align> {
 }
 
 pub fn find_style(attrs: &[Attribute]) -> Option<String> {
-    AttrIter::new(attrs).find_map(|attr| {
+    attr::Iter::new(attrs).find_map(|attr| {
         if let Attr::Style(style) = attr {
             Some(style)
         } else {
@@ -29,162 +30,6 @@ pub fn find_style(attrs: &[Attribute]) -> Option<String> {
         }
     })
 }
-
-pub struct AttrIter<'attrs>(slice::Iter<'attrs, Attribute>);
-
-impl<'attrs> AttrIter<'attrs> {
-    pub fn new(attrs: &'attrs [Attribute]) -> Self {
-        Self(attrs.iter())
-    }
-}
-
-impl<'attrs> Iterator for AttrIter<'attrs> {
-    type Item = Attr;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let Attribute { name, value } = self.0.next()?;
-            let attr = match name.local {
-                local_name!("align") => Align::new(value).map(Attr::Align),
-                local_name!("href") => Some(Attr::Href(value.to_string())),
-                local_name!("id") => Some(Attr::Anchor(format!("#{value}"))),
-                local_name!("width") => value.parse().ok().map(Attr::Width),
-                local_name!("height") => value.parse().ok().map(Attr::Height),
-                local_name!("src") => Some(Attr::Src(value.to_string())),
-                local_name!("start") => value.parse().ok().map(Attr::Start),
-                local_name!("style") => Some(Attr::Style(value.to_string())),
-                local_name!("type") => {
-                    (value.to_string() == "checkbox").then_some(Attr::IsCheckbox)
-                }
-                local_name!("checked") => Some(Attr::IsChecked),
-                _ => continue,
-            };
-
-            if attr.is_some() {
-                break attr;
-            }
-        }
-    }
-}
-
-pub enum Attr {
-    Align(Align),
-    Href(String),
-    Anchor(String),
-    Width(Px),
-    Height(Px),
-    Src(String),
-    Start(usize),
-    Style(String),
-    IsCheckbox,
-    IsChecked,
-}
-
-impl Attr {
-    pub fn to_anchor(&self) -> Option<String> {
-        if let Self::Anchor(name) = self {
-            Some(name.to_owned())
-        } else {
-            None
-        }
-    }
-}
-
-pub struct StyleIter<'style>(std::str::Split<'style, char>);
-
-impl<'style> StyleIter<'style> {
-    pub fn new(style: &'style str) -> Self {
-        Self(style.split(';'))
-    }
-}
-
-impl<'style> Iterator for StyleIter<'style> {
-    type Item = Style;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let part = self.0.next()?;
-
-            if let Some(bg_color) = part
-                .strip_prefix("background-color:#")
-                .and_then(|hex_str| u32::from_str_radix(hex_str, 16).ok())
-            {
-                return Some(Style::BackgroundColor(bg_color));
-            } else if let Some(color) = part
-                .strip_prefix("color:#")
-                .and_then(|hex_str| u32::from_str_radix(hex_str, 16).ok())
-            {
-                return Some(Style::Color(color));
-            } else if let Some(w) = part.strip_prefix("font-weight:").and_then(FontWeight::new) {
-                return Some(Style::FontWeight(w));
-            } else if let Some(s) = part.strip_prefix("font-style:").and_then(FontStyle::new) {
-                return Some(Style::FontStyle(s));
-            } else if let Some(d) = part
-                .strip_prefix("text-decoration:")
-                .and_then(TextDecoration::new)
-            {
-                return Some(Style::TextDecoration(d));
-            }
-        }
-    }
-}
-
-pub enum Style {
-    BackgroundColor(u32),
-    Color(u32),
-    FontWeight(FontWeight),
-    FontStyle(FontStyle),
-    TextDecoration(TextDecoration),
-}
-
-#[derive(Default, PartialEq, Eq)]
-pub enum FontWeight {
-    #[default]
-    Normal,
-    Bold,
-}
-
-impl FontWeight {
-    pub fn new(s: &str) -> Option<Self> {
-        match s {
-            "bold" => Some(Self::Bold),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Default, PartialEq, Eq)]
-pub enum FontStyle {
-    #[default]
-    Normal,
-    Italic,
-}
-
-impl FontStyle {
-    pub fn new(s: &str) -> Option<Self> {
-        match s {
-            "italic" => Some(Self::Italic),
-            _ => None,
-        }
-    }
-}
-
-#[derive(Default, PartialEq, Eq)]
-pub enum TextDecoration {
-    #[default]
-    Normal,
-    Underline,
-}
-
-impl TextDecoration {
-    pub fn new(s: &str) -> Option<Self> {
-        match s {
-            "underline" => Some(Self::Underline),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HeaderType {
     H1,

--- a/src/interpreter/html/style.rs
+++ b/src/interpreter/html/style.rs
@@ -1,0 +1,94 @@
+pub struct Iter<'style>(std::str::Split<'style, char>);
+
+impl<'style> Iter<'style> {
+    pub fn new(style: &'style str) -> Self {
+        Self(style.split(';'))
+    }
+}
+
+impl<'style> Iterator for Iter<'style> {
+    type Item = Style;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let part = self.0.next()?;
+
+            if let Some(bg_color) = part
+                .strip_prefix("background-color:#")
+                .and_then(|hex_str| u32::from_str_radix(hex_str, 16).ok())
+            {
+                return Some(Style::BackgroundColor(bg_color));
+            } else if let Some(color) = part
+                .strip_prefix("color:#")
+                .and_then(|hex_str| u32::from_str_radix(hex_str, 16).ok())
+            {
+                return Some(Style::Color(color));
+            } else if let Some(w) = part.strip_prefix("font-weight:").and_then(FontWeight::new) {
+                return Some(Style::FontWeight(w));
+            } else if let Some(s) = part.strip_prefix("font-style:").and_then(FontStyle::new) {
+                return Some(Style::FontStyle(s));
+            } else if let Some(d) = part
+                .strip_prefix("text-decoration:")
+                .and_then(TextDecoration::new)
+            {
+                return Some(Style::TextDecoration(d));
+            }
+        }
+    }
+}
+
+pub enum Style {
+    BackgroundColor(u32),
+    Color(u32),
+    FontWeight(FontWeight),
+    FontStyle(FontStyle),
+    TextDecoration(TextDecoration),
+}
+
+#[derive(Default, PartialEq, Eq)]
+pub enum FontWeight {
+    #[default]
+    Normal,
+    Bold,
+}
+
+impl FontWeight {
+    pub fn new(s: &str) -> Option<Self> {
+        match s {
+            "bold" => Some(Self::Bold),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Default, PartialEq, Eq)]
+pub enum FontStyle {
+    #[default]
+    Normal,
+    Italic,
+}
+
+impl FontStyle {
+    pub fn new(s: &str) -> Option<Self> {
+        match s {
+            "italic" => Some(Self::Italic),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Default, PartialEq, Eq)]
+pub enum TextDecoration {
+    #[default]
+    Normal,
+    Underline,
+}
+
+impl TextDecoration {
+    pub fn new(s: &str) -> Option<Self> {
+        match s {
+            "underline" => Some(Self::Underline),
+            _ => None,
+        }
+    }
+}

--- a/src/interpreter/html/tag_name.rs
+++ b/src/interpreter/html/tag_name.rs
@@ -1,4 +1,4 @@
-use super::html::HeaderType;
+use super::HeaderType;
 
 use html5ever::{local_name, LocalNameStaticSet};
 use string_cache::Atom;

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -16,8 +16,9 @@ use crate::text::{Text, TextBox};
 use crate::utils::{markdown_to_html, Align};
 use crate::{Element, ImageCache, InlyneEvent};
 use html::{
-    Attr, AttrIter, Element as InterpreterElement, FontStyle, FontWeight, Style, StyleIter,
-    TagName, TextDecoration,
+    attr,
+    style::{self, FontStyle, FontWeight, Style, TextDecoration},
+    Attr, Element as InterpreterElement, TagName,
 };
 
 use comrak::Anchorizer;
@@ -339,7 +340,7 @@ impl HtmlInterpreter {
                 self.current_textbox.set_align_or_default(align);
             }
             TagName::Anchor => {
-                for attr in AttrIter::new(&tag.attrs) {
+                for attr in attr::Iter::new(&tag.attrs) {
                     match attr {
                         Attr::Href(link) => self.state.text_options.link.push(link),
                         Attr::Anchor(a) => self.current_textbox.set_anchor(a),
@@ -355,7 +356,7 @@ impl HtmlInterpreter {
                 let mut align = None;
                 let mut size = None;
                 let mut src = None;
-                for attr in AttrIter::new(&tag.attrs) {
+                for attr in attr::Iter::new(&tag.attrs) {
                     match attr {
                         Attr::Align(a) => align = Some(a),
                         Attr::Width(w) => size = Some(ImageSize::width(w)),
@@ -429,7 +430,7 @@ impl HtmlInterpreter {
             TagName::BoldOrStrong => self.state.text_options.bold += 1,
             TagName::Code => self.state.text_options.code += 1,
             TagName::ListItem => {
-                for attr in AttrIter::new(&tag.attrs) {
+                for attr in attr::Iter::new(&tag.attrs) {
                     self.state.pending_anchor = attr.to_anchor();
                 }
 
@@ -457,7 +458,7 @@ impl HtmlInterpreter {
             }
             TagName::OrderedList => {
                 let mut start_index = 1;
-                for attr in AttrIter::new(&tag.attrs) {
+                for attr in attr::Iter::new(&tag.attrs) {
                     if let Attr::Start(start) = attr {
                         start_index = start;
                     }
@@ -486,7 +487,7 @@ impl HtmlInterpreter {
             TagName::PreformattedText => {
                 self.push_current_textbox();
                 let style_str = html::find_style(&tag.attrs).unwrap_or_default();
-                for style in StyleIter::new(&style_str) {
+                for style in style::Iter::new(&style_str) {
                     if let Style::BackgroundColor(color) = style {
                         let native_color = self.native_color(color);
                         self.current_textbox.set_background_color(native_color);
@@ -499,7 +500,7 @@ impl HtmlInterpreter {
             // blocks working
             TagName::Span => {
                 let style_str = html::find_style(&tag.attrs).unwrap_or_default();
-                for style in StyleIter::new(&style_str) {
+                for style in style::Iter::new(&style_str) {
                     match style {
                         Style::Color(color) => {
                             self.state.span.color = native_color(color, &self.surface_format)
@@ -514,7 +515,7 @@ impl HtmlInterpreter {
             TagName::Input => {
                 let mut is_checkbox = false;
                 let mut is_checked = false;
-                for attr in AttrIter::new(&tag.attrs) {
+                for attr in attr::Iter::new(&tag.attrs) {
                     match attr {
                         Attr::IsCheckbox => is_checkbox = true,
                         Attr::IsChecked => is_checked = true,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,6 +1,4 @@
-mod element;
 mod html;
-mod tag_name;
 #[cfg(test)]
 mod tests;
 
@@ -17,9 +15,10 @@ use crate::positioner::{Positioned, Row, Section, Spacer, DEFAULT_MARGIN};
 use crate::text::{Text, TextBox};
 use crate::utils::{markdown_to_html, Align};
 use crate::{Element, ImageCache, InlyneEvent};
-use element::Element as InterpreterElement;
-use html::{Attr, AttrIter, FontStyle, FontWeight, Style, StyleIter, TextDecoration};
-use tag_name::TagName;
+use html::{
+    Attr, AttrIter, Element as InterpreterElement, FontStyle, FontWeight, Style, StyleIter,
+    TagName, TextDecoration,
+};
 
 use comrak::Anchorizer;
 use glyphon::FamilyOwned;


### PR DESCRIPTION
The `attr` and `style` stuff has enough code to deserve their own modules