### PR TITLE
Inherit align for headers

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -528,7 +528,8 @@ impl HtmlInterpreter {
                     .push(InterpreterElement::ordered_list(start_index));
             }
             TagName::Header(header_type) => {
-                let align = html::find_align(&tag.attrs);
+                let mut align = html::find_align(&tag.attrs);
+                align = self.align_or_inherit(align);
                 self.push_current_textbox();
                 self.push_spacer();
                 if let html::HeaderType::H1 = header_type {

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__header_inherit_align.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__header_inherit_align.snap
@@ -1,0 +1,52 @@
+---
+source: src/interpreter/tests.rs
+description: " --- md\n\n\n<div align=\"center\">\n  <h4>\n    <a href=\"#install\">\n      Install\n    </a>\n    <span> | </span>\n    <a href=\"#usage\">\n      Usage\n    </a>\n  </h4>\n</div>\n\n --- html\n\n<div align=\"center\">\n  <h4>\n    <a href=\"#install\">\n      Install\n    </a>\n    <span> | </span>\n    <a href=\"#usage\">\n      Usage\n    </a>\n  </h4>\n</div>\n"
+expression: "interpret_md_with_opts(text, opts)"
+---
+[
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+    TextBox(
+        TextBox {
+            align: Center,
+            is_anchor: Some("#install---------usage-"),
+            texts: [
+                Text {
+                    text: "Install",
+                    color: Some(Color { r: 0.09, g: 0.13, b: 1.00 }),
+                    style: BOLD ,
+                    link: Some("#install"),
+                    ..
+                },
+                Text {
+                    text: " ",
+                    default_color: Color(BLACK),
+                    ..
+                },
+                Text {
+                    text: " | ",
+                    default_color: Color(BLACK),
+                    style: BOLD ,
+                    ..
+                },
+                Text {
+                    text: "      Usage",
+                    color: Some(Color { r: 0.09, g: 0.13, b: 1.00 }),
+                    style: BOLD ,
+                    link: Some("#usage"),
+                    ..
+                },
+                Text {
+                    text: " ",
+                    default_color: Color(BLACK),
+                    ..
+                },
+            ],
+            ..
+        },
+    ),
+    Spacer(
+        InvisibleSpacer(5),
+    ),
+]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -342,6 +342,20 @@ _italic_
 <u>underline</u>
 ";
 
+// TODO: this still has all sorts of issues (the anchor and extra whitespace)
+const HEADER_INHERIT_ALIGN: &str = r##"
+<div align="center">
+  <h4>
+    <a href="#install">
+      Install
+    </a>
+    <span> | </span>
+    <a href="#usage">
+      Usage
+    </a>
+  </h4>
+</div>"##;
+
 snapshot_interpreted_elements!(
     (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
@@ -362,6 +376,7 @@ snapshot_interpreted_elements!(
     (horizontal_ruler, HORIZONTAL_RULER),
     (small_text, SMALL_TEXT),
     (text_styles, TEXT_STYLES),
+    (header_inherit_align, HEADER_INHERIT_ALIGN),
 );
 
 const UNDERLINE_IN_CODEBLOCK: &str = "\


### PR DESCRIPTION
The start of `sqlx`'s README is all sorts of messed up when rendering with `inlyne`. This partially fixes the `Install | Usage | Docs` alignment, but there's plenty of other issues that still need fixing

![image](https://github.com/trimental/inlyne/assets/30302768/87a70cd4-6553-45cf-aed9-f47ae21d2912)

Namely there is extra whitespace that shouldn't be included in the `Install |     Usage |     Docs`, the clickable link regions for that whole portion are messed up, and the badges are displayed vertically when they should display inline (likely because they're center aligned when it looks like inline images currently only work when left aligned which is wrong)