### PR TITLE
Temporarily disable partial footnotes support

### DIFF
--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -219,6 +219,7 @@ macro_rules! snapshot_interpreted_elements {
     }
 }
 
+#[allow(unused)]
 const FOOTNOTES_LIST_PREFIX: &str = "\
 This sentence[^1] has two footnotes[^2]
 
@@ -357,7 +358,7 @@ const HEADER_INHERIT_ALIGN: &str = r##"
 </div>"##;
 
 snapshot_interpreted_elements!(
-    (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
+    // (footnotes_list_prefix, FOOTNOTES_LIST_PREFIX),
     (checklist_has_no_text_prefix, CHECKLIST_HAS_NO_TEXT_PREFIX),
     (code_block_bg_color, CODE_BLOCK_BG_COLOR),
     (bare_link_gets_autolinked, BARE_LINK_GETS_AUTOLINKED),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -151,7 +151,7 @@ pub fn markdown_to_html(md: &str, syntax_theme: SyntectTheme) -> String {
     options.extension.table = true;
     options.extension.strikethrough = true;
     options.extension.tasklist = true;
-    options.extension.footnotes = true;
+    // options.extension.footnotes = true;
     options.extension.front_matter_delimiter = Some("---".to_owned());
     options.extension.shortcodes = true;
     options.parse.smart = true;


### PR DESCRIPTION
Footnotes only partially work currently (anchors are attached to textboxes and footnotes make it much more common to have _multiple_ anchors within a textbox). This temporarily disables footnotes, so that v0.4 can be released without a feature that's known to be partially broken