### PR TITLE
Install `libwayland-dev` on ubuntu CI

### DIFF
--- a/ci/ubuntu-install-packages
+++ b/ci/ubuntu-install-packages
@@ -12,4 +12,5 @@ fi
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
   libfontconfig1-dev \
+  libwayland-dev \
   jq


### PR DESCRIPTION
The `wayland` feature being default means that we need to install the proper dev libraries in CI for creating the pre-built releases. This _should_ (:crossed_fingers:) fix the release CI